### PR TITLE
fix #119 search for server.xml

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export function deactivate(): void {
  * @param projectProvider Liberty Dev projects
  */
 export function registerFileWatcher(projectProvider: ProjectProvider): void {
-	const watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("{**/pom.xml,**/build.gradle,**/settings.gradle}");
+const watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("{**/pom.xml,**/build.gradle,**/settings.gradle,**/src/main/liberty/config/server.xml}");
 	watcher.onDidCreate(async () => {
 		projectProvider.refresh();
 	});

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -147,7 +147,8 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 
 	/**
 	 * Checks if given build file exists in existing project map (<code>this.projects</code>).
-	 * If it exists, it will be added to the given <code>projectMap</code>.
+	 * If it exists, then the corresponding liberty project will be added to the given 
+	 * <code>projectsMap</code>.
 	 * 
 	 * @param buildFilePath The build file to check (full path to pom.xml or build.gradle)
 	 * @param projectType Project type
@@ -216,7 +217,9 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		}
 
 		/* 
-		 * Find the projects by server.xml
+		 * Find the projects by server.xml.
+		 * This method assumes if pom.xml is under project root, then the server.xml is in
+		 * ./src/main/liberty/config/server.xml
 		 */
 		for (const serverXML of serverXMLPaths) {
 			const folder = vscodePath.parse(vscodePath.resolve(serverXML, '../../../../../')).dir;

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -222,7 +222,7 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		 * ./src/main/liberty/config/server.xml
 		 */
 		for (const serverXML of serverXMLPaths) {
-			const folder = vscodePath.parse(vscodePath.resolve(serverXML, '../../../../../')).dir;
+			const folder = vscodePath.parse(vscodePath.resolve(serverXML, '../../../../')).dir;
 			const pomFile = vscodePath.resolve(folder, 'pom.xml');
 			
 			if ( fse.existsSync(pomFile)) {
@@ -235,8 +235,8 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 				const gradleFile = vscodePath.resolve(folder, 'build.gradle');
 				if ( fse.existsSync (gradleFile) ) {
 					if ( !this.addExistingProjectToNewProjectsMap(gradleFile, LIBERTY_GRADLE_PROJECT, newProjectsMap) ) {
-						const project = await createProject(this._context, pomFile, LIBERTY_GRADLE_PROJECT);
-						newProjectsMap.set(pomFile, project);
+						const project = await createProject(this._context, gradleFile, LIBERTY_GRADLE_PROJECT);
+						newProjectsMap.set(gradleFile, project);
 					}
 				}
 			}			

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -216,7 +216,7 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		}
 
 		/* 
-		 * Finde the projects by server.xml
+		 * Find the projects by server.xml
 		 */
 		for (const serverXML of serverXMLPaths) {
 			const folder = vscodePath.parse(vscodePath.resolve(serverXML, '../../../../../')).dir;

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -158,7 +158,6 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 	private addExistingProjectToNewProjectsMap (buildFilePath: string, projectType: string, projectsMap: Map<string, LibertyProject> ) : Boolean {
 		let added = false;
 		if (this.projects.has(buildFilePath)) {
-			// check version of liberty-maven-plugin to see if it is valid for contatiners
 			const project = this.projects.get(buildFilePath);
 			if (project !== undefined) {
 				if (project.contextValue != projectType) {


### PR DESCRIPTION
Added code to search for `server.xml` (`**/src/main/liberty/config/server.xml`) for folders that are not liberty project folders.

If a folder contains the above `server.xml` file, then will check if the root contains `pom.xml` or `build.gradle` and based on the findings the folder will be added to the new project map.
