### PR TITLE
Narrow down files for LS to run on

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,8 +132,8 @@ function startupLanguageServer(context: ExtensionContext) {
         synchronize: {
             configurationSection: ["properties", "plaintext"],
             fileEvents: [
-                workspace.createFileSystemWatcher("**/*.properties"),
-                workspace.createFileSystemWatcher("**/*.env")
+                workspace.createFileSystemWatcher("**/bootstrap.properties"),
+                workspace.createFileSystemWatcher("**/server.env")
             ],
         }
     };


### PR DESCRIPTION
Small fix to run the language server only on `server.env` and `bootstrap.properties` files instead of all `.env` and `.properties` files.

When we determine the proper ways to detect if it is for a Liberty project, will update this. This may become a more involved process if they can be associated to Liberty by reference from another file.