### PR TITLE
Add Liberty debug config

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,24 @@
 		"redhat.vscode-microprofile"
 	],
 	"contributes": {
+		"debuggers": [
+			{
+				"type": "liberty",
+				"configurationSnippets": [
+					{
+						"label":  "Liberty: Attach to dev mode",
+						"body": {
+							"type": "java",
+							"name": "Attach to Liberty dev mode",
+							"request": "attach",
+							"hostName": "localhost",
+							"port": "7777"
+						  }
+  
+					}
+				]
+			}
+		],
 		"views": {
 			"explorer": [
 				{


### PR DESCRIPTION
Contributes a "Liberty: Attach to dev mode" debug configuration that works identical to "Java: Attach to Remote Program" with the Liberty defaults "localhost" and "7777" pre-loaded.

Fixes #128 
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>