### PR TITLE
Update README and declare explicit dep on vscode-xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,7 @@
 # Liberty Tools for VS Code
 
-## Building the Liberty Language Server Prototype
-
-This branch contributes a VS Code language server client consuming the [language server for Liberty configuration prototype](https://github.com/OpenLiberty/liberty-language-server).
-
-To build:
-1. Install the [XML by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml) VS Code Extension. This extension contributes the LemMinx language server (language support for XML).
-2. Clone the liberty-language-server project: `git clone https://github.com/OpenLiberty/liberty-language-server.git`
-3. In the same folder, clone this repo: `git clone https://github.com/OpenLiberty/open-liberty-tools-vscode.git`
-Directory structure should appear as:
-```
-├── liberty-language-server
-│   ├── lemminx-liberty
-│   ├── liberty-ls
-└── open-liberty-tools-vscode
-```
-4. Navigate to the `open-liberty-tools-vscode` project and checkout the "liberty-ls-prototype" branch: `git checkout -b liberty-ls-prototype origin/liberty-ls-prototype`.
-3. Install dependencies: `npm install`
-4. Build the liberty-language-server prototype: `npm run build`. Runs the [gulpfile.js](gulpfile.js) file. Builds the lemminx-liberty and liberty-ls components, and copies the corresponding jars to the /open-liberty-tools/vscode/jars directory.
-```
-├── open-liberty-tools-vscode
-│   ├── jars
-│   │   ├── lemminx-liberty-x.x-SNAPSHOT-jar-with-dependencies.jar
-│   │   └── liberty.ls-1.0-SNAPSHOT-jar-with-dependencies.jar
-
-```
-5. Run the extension through the "Run and Debug" menu of VS Code, or using shortcut `F5`. 
-6. Open a server.xml file in a Liberty project, you should see completion, hover for more information, and diagnostic information within the file.
-
-Hover over an element in a server.xml file for more information:
-![Server.xml element hover](images/liberty-ls-prototype/element-hover.png)
-
-Feature completion suggestions: 
-![Server.xml feature completion](images/liberty-ls-prototype/feature-completion.png)
-
-Feature diagnostics for invalid features:
-![Server.xml feature diagnostic](images/liberty-ls-prototype/feature-diagnostic.png)
----
-
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/Open-Liberty.open-liberty-tools-vscode.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.open-liberty-tools-vscode)
-[![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
+[![Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Open-Liberty.liberty-dev-vscode-ext?style=for-the-badge&label=VS%20Market "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
+[![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?style=for-the-badge&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
 A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dashboard, you can start, stop, or interact with Liberty dev mode on all available [Liberty Maven](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) or [Liberty Gradle](https://github.com/OpenLiberty/ci.gradle/blob/master/docs/libertyDev.md) projects in your workspace.
 
@@ -58,6 +20,11 @@ A VS Code extension for Open Liberty. The extension will detect your Liberty Mav
 - Start dev mode with custom parameters
 - Run tests
 - View unit and integration test reports
+
+Liberty Tools for VS Code consumes the [Liberty Config Language Server](https://github.com/OpenLiberty/liberty-language-server) providing language server features for Liberty server configuration files:
+- server.env
+- bootstrap.properties
+- server.xml
 
 ## Commands
 
@@ -91,6 +58,7 @@ The following settings provided by external extensions will be honoured when exe
 ## Requirements
 
 - [Tools for MicroProfile extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile)
+- [XML extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
 
 ## Contributing
 
@@ -100,21 +68,23 @@ Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pul
 
 To build the extension locally:
 
-1. `git clone https://github.com/OpenLiberty/open-liberty-tools-vscode`
-2. `cd open-liberty-tools-vscode`
-3. Execute `npm install`
+1. `git clone https://github.com/OpenLiberty/liberty-tools-vscode`
+2. `cd liberty-tools-vscode`
+3. Run `npm install`
+4. Run `npm run build`
+5. Run `npm run compile`
 4. Run the extension in Debug and Run mode by selecting `Run Extension` or `F5`
 
    Alternatively, build a `.vsix` file:
 
-   - `vsce package` to generate the `open-liberty-tools-vscode-xxx.vsix` file
+   - `vsce package` to generate the `liberty-tools-vscode-xxx.vsix` file
    - Install the extension to VS Code by `View/Command Palette`
-   - Select `Extensions: Install from VSIX...` and choose the generated `open-liberty-tools-vscode-xxx.vsix` file
+   - Select `Extensions: Install from VSIX...` and choose the generated `liberty-tools-vscode-xxx.vsix` file
 
 ### Localization
 
 #### package.json
-This follows vscode extenstion standard: add localized strings in `package.nls.{locale}.json`.
+This follows vscode extension standard: add localized strings in `package.nls.{locale}.json`.
 The default nls message file is `package.nls.json`.
 
 #### Source code

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 	],
 	"main": "./dist/extension",
 	"extensionDependencies": [
-		"redhat.vscode-microprofile"
+		"redhat.vscode-microprofile",
+		"redhat.vscode-xml"
 	],
 	"contributes": {
 		"xml.javaExtensions": [


### PR DESCRIPTION
Instructions for building the Liberty Config Language Server will be on the LS repo: https://github.com/OpenLiberty/liberty-language-server

Added explicit dependency on `redhat.vscode-xml` as it is needed for the server.xml support delivered through the Liberty Config Language Server (will install XML by Red Hat to VS Code if it is not already installed).

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>