### PR TITLE
fix java checks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,13 @@ function startupLibertyLanguageServer(context: ExtensionContext, api: JavaExtens
         context.subscriptions.push(disposable);
 
         return libertyClient.onReady();
-    })
+    }).catch((error) => {
+        window.showErrorMessage(error.message, error.label).then((selection) => {
+            if (error.label && error.label === selection && error.openUrl) {
+                commands.executeCommand('vscode.open', error.openUrl);
+            }
+        });
+    });
 }
 
 function startupJakartaLangServer(context: ExtensionContext, api: JavaExtensionAPI) {
@@ -219,7 +225,13 @@ function startupJakartaLangServer(context: ExtensionContext, api: JavaExtensionA
     
         context.subscriptions.push(jakartaClient.start());
         return jakartaClient.onReady();
-    })
+    }).catch((error) => {
+        window.showErrorMessage(error.message, error.label).then((selection) => {
+            if (error.label && error.label === selection && error.openUrl) {
+                commands.executeCommand('vscode.open', error.openUrl);
+            }
+        });
+    });
 }
 
 function toggleItem(editor: TextEditor | undefined, item: vscode.StatusBarItem) {

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -48,14 +48,19 @@ export interface RequirementsData {
  */
 export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
 
+    console.log("Resolving requirements...");
+
     // Use the embedded JRE from 'redhat.java' if it exists
-    const requirementsData = api.javaRequirement;
-    if (requirementsData) {
-        return Promise.resolve(requirementsData);
-    }
+    // const requirementsData = api.javaRequirement;
+    // if (requirementsData) {
+    //     console.log("Promise should resolve");
+    //     console.log("requirementsData: " + requirementsData);
+    //     return Promise.resolve(requirementsData);
+    // }
 
     const javaHome = await checkJavaRuntime();
     const javaVersion = await checkJavaVersion(javaHome);
+    console.log("javaHome: " + javaHome + "; javaVersion: " + javaVersion);
     return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});
 }
 

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -47,6 +47,13 @@ export interface RequirementsData {
  *
  */
 export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
+
+    // Use the embedded JRE from 'redhat.java' if it exists
+    const requirementsData = api.javaRequirement;
+    if (requirementsData && api.javaRequirement.tooling_jre_version >= 17) {
+        return Promise.resolve(requirementsData);
+    }
+
     const javaHome = await checkJavaRuntime();
     const javaVersion = await checkJavaVersion(javaHome);
     return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -47,20 +47,8 @@ export interface RequirementsData {
  *
  */
 export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
-
-    console.log("Resolving requirements...");
-
-    // Use the embedded JRE from 'redhat.java' if it exists
-    // const requirementsData = api.javaRequirement;
-    // if (requirementsData) {
-    //     console.log("Promise should resolve");
-    //     console.log("requirementsData: " + requirementsData);
-    //     return Promise.resolve(requirementsData);
-    // }
-
     const javaHome = await checkJavaRuntime();
     const javaVersion = await checkJavaVersion(javaHome);
-    console.log("javaHome: " + javaHome + "; javaVersion: " + javaVersion);
     return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});
 }
 


### PR DESCRIPTION
#154 

1) Properly forward the message.
2) Do not default to JRE used by `redhat.java`, as we have a more strict version check.

Included are the screenshots for an outdated Java version.

![image](https://user-images.githubusercontent.com/8934136/203381165-c4649afa-96a5-442f-bff9-4454c368c256.png)
![image](https://user-images.githubusercontent.com/8934136/203381184-ab80a7c2-2565-42f8-aeb0-18b0bdb12892.png)
