### PR TITLE
Pull lsp4jakarta jars from repo.eclipse.org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          cache: 'maven'
       - name: Build Liberty Tools for VSCode
         working-directory: ./liberty-tools-vscode
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,11 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: liberty-tools-vscode
-      - name: Checkout lsp4jakarta
-        uses: actions/checkout@v3
-        with:
-          repository: eclipse/lsp4jakarta
-          path: lsp4jakarta
       - name: Setup Java 17
         uses: actions/setup-java@v3
         with:
@@ -35,7 +30,6 @@ jobs:
             npm install
             npm install -g vsce
             npm run build
-            npm run buildJakarta
             npm run compile
             vsce package
       - name: Archive artifacts

--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pul
 To build the extension locally:
 
 1. `git clone https://github.com/OpenLiberty/liberty-tools-vscode`
-2. `git clone https://github.com/eclipse/lsp4jakarta.git` - Make sure the `lsp4jakarta` and `liberty-tools-vscode` projects are located in the same directory.
-3. `cd liberty-tools-vscode`
-4. Run `npm install`
-5. Run `npm run build`
-6. Run `npm run buildJakarta`
-7. Run `npm run compile`
-8. Run the extension in Debug and Run mode by selecting `Run Extension` or `F5`
+2. `cd liberty-tools-vscode`
+3. Run `npm install`
+4. Run `npm run build`
+5. Run `npm run compile`
+6. Run the extension in Debug and Run mode by selecting `Run Extension` or `F5`
 
    Alternatively, build a `.vsix` file:
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,8 @@ const libertyLemminxName = "liberty-langserver-lemminx-" + libertyVersion + "-ja
 const libertyLemminxDir = "../liberty-language-server/lemminx-liberty";
 const libertyLSName = "liberty-langserver-" + libertyVersion + "-jar-with-dependencies.jar";
 const libertyLSDir = "../liberty-language-server/liberty-ls";
-const lsp4jakartaName = "org.eclipse.lsp4jakarta.jdt.core-" + jakartaVersion + ".jar";
-const lsp4jakartaJdt = "../lsp4jakarta/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core";
+const jakartaJdtName = "org.eclipse.lsp4jakarta.jdt.core-" + jakartaVersion + ".jar";
+const jakartaJdtDir = "../lsp4jakarta/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core";
 const jakartaLSName = "org.eclipse.lsp4jakarta.ls-" + jakartaVersion + "-jar-with-dependencies.jar";
 const jakartaLSDir = "../lsp4jakarta/jakarta.ls";
 
@@ -37,10 +37,10 @@ gulp.task("buildLibertyServer", (done) => {
 
 gulp.task("buildJakartaJdt", (done) => {
   cp.execSync("mvn clean install", {
-    cwd: lsp4jakartaJdt,
+    cwd: jakartaJdtDir,
     stdio: "inherit",
   });
-  gulp.src(lsp4jakartaJdt + "/target/" + lsp4jakartaName).pipe(gulp.dest("./jars"));
+  gulp.src(jakartaJdtDir + "/target/" + jakartaJdtName).pipe(gulp.dest("./jars"));
   done();
 });
 
@@ -92,7 +92,7 @@ const jakartaLSURL = sonatypeURL + jakartaReleaseLevelString + jakartaGroupIdStr
 gulp.task("downloadLSP4JakartaJars", (done) => {
   download({
       url: jakartaJDTURL,
-      file: lsp4jakartaName,
+      file: jakartaJdtName,
     })
     .pipe(gulp.dest("./jars"));
     download({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,17 +2,19 @@ const gulp = require("gulp");
 const download = require("gulp-download2");
 const cp = require("child_process");
 
-const groupId = "io.openliberty.tools";
-const version = "1.0-SNAPSHOT";
+const libertyGroupId = "io.openliberty.tools";
+const libertyVersion = "1.0-SNAPSHOT";
+const jakartaGroupId = "org.eclipse.lsp4jakarta";
+const jakartaVersion = "0.0.1-SNAPSHOT";
 var releaseLevel = "snapshots"; //snapshots or releases
 
-const libertyLemminxName = "liberty-langserver-lemminx-" + version + "-jar-with-dependencies.jar";
+const libertyLemminxName = "liberty-langserver-lemminx-" + libertyVersion + "-jar-with-dependencies.jar";
 const libertyLemminxDir = "../liberty-language-server/lemminx-liberty";
-const libertyLSName = "liberty-langserver-" + version + "-jar-with-dependencies.jar";
+const libertyLSName = "liberty-langserver-" + libertyVersion + "-jar-with-dependencies.jar";
 const libertyLSDir = "../liberty-language-server/liberty-ls";
-const lsp4jakartaName = "org.eclipse.lsp4jakarta.jdt.core-0.0.1-SNAPSHOT.jar";
+const lsp4jakartaName = "org.eclipse.lsp4jakarta.jdt.core-" + jakartaVersion + ".jar";
 const lsp4jakartaJdt = "../lsp4jakarta/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core";
-const jakartaLSName = "org.eclipse.lsp4jakarta.ls-0.0.1-SNAPSHOT-jar-with-dependencies.jar";
+const jakartaLSName = "org.eclipse.lsp4jakarta.ls-" + jakartaVersion + "-jar-with-dependencies.jar";
 const jakartaLSDir = "../lsp4jakarta/jakarta.ls";
 
 gulp.task("buildLemminxLiberty", (done) => {
@@ -55,12 +57,12 @@ gulp.task("buildJakartaLs", (done) => {
 //https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=io.openliberty.tools&a=liberty-langserver&c=jar-with-dependencies&v=1.0-SNAPSHOT
 const sonatypeURL = "https://oss.sonatype.org/service/local/artifact/maven/content";
 const releaseLevelString = "?r=" + releaseLevel;
-const groupIdString = "&g=" + groupId;
-const versionString = "&v=" + version;
+const libertyGroupIdString = "&g=" + libertyGroupId;
+const libertyVersionString = "&v=" + libertyVersion;
 const classifierString = "&c=jar-with-dependencies";
 
-const libertyLemminxURL = sonatypeURL + releaseLevelString + groupIdString + "&a=liberty-langserver-lemminx" + classifierString + versionString;
-const libertyLSURL = sonatypeURL + releaseLevelString + groupIdString + "&a=liberty-langserver" + classifierString + versionString;
+const libertyLemminxURL = sonatypeURL + releaseLevelString + libertyGroupIdString + "&a=liberty-langserver-lemminx" + classifierString + libertyVersionString;
+const libertyLSURL = sonatypeURL + releaseLevelString + libertyGroupIdString + "&a=liberty-langserver" + classifierString + libertyVersionString;
 
 gulp.task("downloadLibertyLSJars", (done) => {
   download({
@@ -71,6 +73,31 @@ gulp.task("downloadLibertyLSJars", (done) => {
     download({
       url: libertyLSURL,
       file: libertyLSName,
+    })
+    .pipe(gulp.dest("./jars"));
+  done();
+});
+
+//https://repo.eclipse.org/service/local/artifact/maven/content?r=snapshots&g=org.eclipse.lsp4jakarta&a=org.eclipse.lsp4jakarta.jdt.core&v=0.0.1-SNAPSHOT
+//https://repo.eclipse.org/service/local/artifact/maven/content?r=snapshots&g=org.eclipse.lsp4jakarta&a=org.eclipse.lsp4jakarta.ls&c=jar-with-dependencies&v=0.0.1-SNAPSHOT
+const eclipseRepoURL = "https://repo.eclipse.org/service/local/artifact/maven/content";
+const jakartaReleaseLevelString = "?r=" + releaseLevel;
+const jakartaGroupIdString = "&g=" + jakartaGroupId;
+const jakartaVersionString = "&v=" + jakartaVersion;
+const jakartaClassifierString = "&c=jar-with-dependencies";
+
+const jakartaJDTURL = sonatypeURL + jakartaReleaseLevelString + jakartaGroupIdString + "&a=org.eclipse.lsp4jakarta.jdt.core" + jakartaVersionString;
+const jakartaLSURL = sonatypeURL + jakartaReleaseLevelString + jakartaGroupIdString + "&a=org.eclipse.lsp4jakarta.ls" + jakartaClassifierString + jakartaVersionString;
+
+gulp.task("downloadLSP4JakartaJars", (done) => {
+  download({
+      url: jakartaJDTURL,
+      file: lsp4jakartaName,
+    })
+    .pipe(gulp.dest("./jars"));
+    download({
+      url: jakartaLSURL,
+      file: jakartaLSName,
     })
     .pipe(gulp.dest("./jars"));
   done();

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
 		"compile": "webpack --mode none",
 		"watch": "webpack --mode development --watch --info-verbosity verbose",
 		"test-compile": "tsc -p ./",
-		"build": "gulp downloadLibertyLSJars",
+		"build": "gulp downloadLibertyLSJars downloadLSP4JakartaJars",
 		"buildLocal": "gulp buildLemminxLiberty buildLibertyServer",
 		"buildJakarta": "gulp buildJakartaJdt buildJakartaLs"
 	},


### PR DESCRIPTION
- `npm run build` now downloads LSP4Jakarta JDT and LS jars
- Removed LSP4Jakarta build step from GHA `build.yaml` 
- Updated `README.md` local build steps

Addresses #159 

Signed-off-by: Matt Bowersox <m.bowersox@ibm.com>