### PR TITLE
Exclude gulpfile from vsix file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ src/
 webpack.config.js
 **/*.map
 node_modules
+**/gulpfile.js


### PR DESCRIPTION
Before with gulpfile:
<img width="488" alt="Screen Shot 2022-12-01 at 2 31 51 PM" src="https://user-images.githubusercontent.com/6548952/205154148-8c1eb688-a223-4bb5-95e7-b18696c38863.png">

After without gulpfile:
<img width="486" alt="Screen Shot 2022-12-01 at 2 31 58 PM" src="https://user-images.githubusercontent.com/6548952/205153763-675ca624-7810-4b17-aae7-c265f8c3e052.png">

Signed-off-by: Matt Bowersox <m.bowersox@ibm.com>

