### PR TITLE
additional warning/check for LemminX Java Version

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,7 @@
     "check.java.runtime.vscode.java.home": "The java.home variable defined in VS Code settings",
     "check.java.runtime.env.jdk.home": "The JDK_HOME environment variable",
     "check.java.runtime.env.java.home": "The JAVA_HOME environment variable",
-    "define.xml.java.home.message": "The Liberty Config Language Server requires Java 17 for functionality. Please set 'xml.java.home' to point to Java 17 in VS Code settings or set JAVA_HOME to point to Java 17.",
+    "define.xml.java.home.message": "The Liberty Config Language Server requires Java 17 for functionality. Please set 'xml.java.home' to point to Java 17 in VS Code settings or set the system JAVA_HOME environment variable to point to Java 17.",
     "check.java.runtime.dismiss.label": "Dismiss",
     "open.jdk.download.part.missing.folder": " points to a missing folder",
     "open.jdk.download.part.no.runtime": " does not point to a Java runtime.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,6 +53,8 @@
     "check.java.runtime.vscode.java.home": "The java.home variable defined in VS Code settings",
     "check.java.runtime.env.jdk.home": "The JDK_HOME environment variable",
     "check.java.runtime.env.java.home": "The JAVA_HOME environment variable",
+    "define.xml.java.home.message": "The Liberty Config Language Server requires Java 17 for functionality. Please define 'xml.java.home' in VS Code settings or point JAVA_HOME to Java 17.",
+    "check.java.runtime.dismiss.label": "Dismiss",
     "open.jdk.download.part.missing.folder": " points to a missing folder",
     "open.jdk.download.part.no.runtime": " does not point to a Java runtime.",
     "open.jdk.download.label": "Get the Java Development Kit",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,7 @@
     "check.java.runtime.vscode.java.home": "The java.home variable defined in VS Code settings",
     "check.java.runtime.env.jdk.home": "The JDK_HOME environment variable",
     "check.java.runtime.env.java.home": "The JAVA_HOME environment variable",
-    "define.xml.java.home.message": "The Liberty Config Language Server requires Java 17 for functionality. Please define 'xml.java.home' in VS Code settings or point JAVA_HOME to Java 17.",
+    "define.xml.java.home.message": "The Liberty Config Language Server requires Java 17 for functionality. Please set 'xml.java.home' to point to Java 17 in VS Code settings or set JAVA_HOME to point to Java 17.",
     "check.java.runtime.dismiss.label": "Dismiss",
     "open.jdk.download.part.missing.folder": " points to a missing folder",
     "open.jdk.download.part.no.runtime": " does not point to a Java runtime.",

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -43,26 +43,34 @@ export interface RequirementsData {
  * Resolves the requirements needed to run the extension.
  * Returns a promise that will resolve to a RequirementsData if
  * all requirements are resolved, it will reject with ErrorData if
- * if any of the requirements fails to resolve.
+ * if any of the requirements fail to resolve.
  *
  */
 export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
 
-    // Use the embedded JRE from 'redhat.java' if it exists
     const requirementsData = api.javaRequirement;
-    if (requirementsData && api.javaRequirement.java_version >= 17 && api.javaRequirement.tooling_jre_version >= 17) {
+    // Java check for LSP4Jakarta and LCLS support
+    // Reuse the embedded JRE from 'redhat.java' if it exists and passes check
+    if (requirementsData && requirementsData.tooling_jre_version >= 17) {
         return Promise.resolve(requirementsData);
     }
 
-    const javaHome = await checkJavaRuntime();
-    const javaVersion = await checkJavaVersion(javaHome);
+    const javaHome = await checkJavaRuntime('java.jdt.ls.java.home');
+    const javaVersion = await checkJavaVersion(javaHome, true);
     return Promise.resolve({tooling_jre: javaHome, tooling_jre_version: javaVersion, java_home: javaHome, java_version: javaVersion});
 }
 
-function checkJavaRuntime(): Promise<string> {
+export async function resolveLclsRequirements(api:JavaExtensionAPI) {
+    if (api.javaRequirement === null || api.javaRequirement.java_version < 17) {
+        const javaHome = await checkJavaRuntime('xml.java.home');
+        return checkJavaVersion(javaHome, false);
+    }
+}
+
+function checkJavaRuntime(property: string): Promise<string> {
     return new Promise((resolve, reject) => {
         let source: string;
-        let javaHome: string|undefined = readJavaHomeConfig();
+        let javaHome: string|undefined = readJavaHomeConfig(property);
 
         if (javaHome) {
             source = localize("check.java.runtime.vscode.java.home");
@@ -97,24 +105,23 @@ function checkJavaRuntime(): Promise<string> {
     });
 }
 
-function readJavaHomeConfig(): string|undefined {
+function readJavaHomeConfig(property: string): string|undefined {
     const config = workspace.getConfiguration();
-    let javaHome = config.get<string>('xml.java.home');
-    if (javaHome === null) {
-        javaHome = config.get<string>('java.jdt.ls.java.home');
-    }
-    if (javaHome === null) {
-        javaHome = config.get<string>('java.home');
-    }
-    return javaHome;
+    let javaHome = config.get<string>(property);
+    return (javaHome != null) ? javaHome : config.get<string>('java.home');
 }
 
-function checkJavaVersion(javaHome: string): Promise<number> {
+// Provided javaHome, parse major version and reject sub Java17
+function checkJavaVersion(javaHome: string, promptDownload: boolean): Promise<number> {
     return new Promise((resolve, reject) => {
         cp.execFile(javaHome + '/bin/java', ['-version'], {}, (error, stdout, stderr) => {
             const javaVersion = parseMajorVersion(stderr);
             if (javaVersion < 17) {
-                openJDKDownload(reject, localize("check.java.runtime.version.outdated"));
+                if (promptDownload) {
+                    openJDKDownload(reject, localize("check.java.runtime.version.outdated"));
+                } else {
+                    defineXmlJavaHome(reject, localize("define.xml.java.home.message"));
+                }
             } else {
                 resolve(javaVersion);
             }
@@ -142,6 +149,14 @@ export function parseMajorVersion(content: string): number {
         javaVersion = parseInt(match[0]);
     }
     return javaVersion;
+}
+
+function defineXmlJavaHome(reject: any, cause: string) {
+    reject({
+        message: cause,
+        label: localize("check.java.runtime.dismiss.label"),
+        replaceClose: false
+    })
 }
 
 function openJDKDownload(reject: any, cause: string) {

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -47,7 +47,6 @@ export interface RequirementsData {
  *
  */
 export async function resolveRequirements(api: JavaExtensionAPI): Promise<RequirementsData> {
-
     const requirementsData = api.javaRequirement;
     // Java check for LSP4Jakarta and LCLS support
     // Reuse the embedded JRE from 'redhat.java' if it exists and passes check
@@ -61,10 +60,8 @@ export async function resolveRequirements(api: JavaExtensionAPI): Promise<Requir
 }
 
 export async function resolveLclsRequirements(api:JavaExtensionAPI) {
-    if (api.javaRequirement === null || api.javaRequirement.java_version < 17) {
-        const javaHome = await checkJavaRuntime('xml.java.home');
-        return checkJavaVersion(javaHome, false);
-    }
+    const javaHome = await checkJavaRuntime('xml.java.home');
+    return checkJavaVersion(javaHome, false);
 }
 
 function checkJavaRuntime(property: string): Promise<string> {

--- a/src/util/requirements.ts
+++ b/src/util/requirements.ts
@@ -50,7 +50,7 @@ export async function resolveRequirements(api: JavaExtensionAPI): Promise<Requir
 
     // Use the embedded JRE from 'redhat.java' if it exists
     const requirementsData = api.javaRequirement;
-    if (requirementsData && api.javaRequirement.tooling_jre_version >= 17) {
+    if (requirementsData && api.javaRequirement.java_version >= 17 && api.javaRequirement.tooling_jre_version >= 17) {
         return Promise.resolve(requirementsData);
     }
 
@@ -99,8 +99,14 @@ function checkJavaRuntime(): Promise<string> {
 
 function readJavaHomeConfig(): string|undefined {
     const config = workspace.getConfiguration();
-    const javaJdtLsHome = config.get<string>('java.jdt.ls.java.home');
-    return javaJdtLsHome === null ? javaJdtLsHome : config.get<string>('java.home');
+    let javaHome = config.get<string>('xml.java.home');
+    if (javaHome === null) {
+        javaHome = config.get<string>('java.jdt.ls.java.home');
+    }
+    if (javaHome === null) {
+        javaHome = config.get<string>('java.home');
+    }
+    return javaHome;
 }
 
 function checkJavaVersion(javaHome: string): Promise<number> {


### PR DESCRIPTION
#185 

A little tough to read in this screenshot, but`ps -ef | grep jar` reveals that the servers use RedHat's included JRE and the LemminX server starts with Java 11.
![image](https://user-images.githubusercontent.com/8934136/206036244-c3b4b982-7683-4457-9e0d-e03dc37c2004.png)

This is the warning received when the language servers continue functionality and LCLS lacks `*.xml` support.
![image](https://user-images.githubusercontent.com/8934136/206048915-0eafc76d-31af-4387-bf95-5b26edd17274.png)


- Requirements for resolve separately, 1) LemminX; 2) LSP4Jakarta and LCLS
  - Server requirements checked reduced: 2 -> 1
  - Refactored 
- LemminX checks:
  - JAVA_HOME -> `xml.java.home` -> `java.home`
- LSP4Jakarta and LCLS
  - RedHat JRE -> `java.jdt.ls.java.home` -> `java.home` -> JAVA_HOME

See issue for further information