### PR TITLE
Clearly document Java 17 requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 We welcome contributions, and request you follow these guidelines.
 
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+
 - [Raising issues](#raising-issues)
 - [Legal](#legal)
 - [Coding Standards](#coding-standards)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome contributions, and request you follow these guidelines.
 
-> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required to run Liberty Tools for Visual Studio Code.
 
 - [Raising issues](#raising-issues)
 - [Legal](#legal)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # Developing Liberty Tools for Visual Studio Code
 
-> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required to run Liberty Tools for Visual Studio Code.
 
 - [Build Liberty Tools for Visual Studio Code](#build-liberty-tools-for-visual-studio-code)
 - [Language Servers](#language-servers)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,7 @@
 # Developing Liberty Tools for Visual Studio Code
 
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+
 - [Build Liberty Tools for Visual Studio Code](#build-liberty-tools-for-visual-studio-code)
 - [Language Servers](#language-servers)
   - [Build Liberty Config Language Server locally](#build-liberty-config-language-server-locally)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Liberty Tools for Visual Studio Code
 
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+
 [![Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Open-Liberty.liberty-dev-vscode-ext?style=for-the-badge&label=VS%20Market "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
 [![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?style=for-the-badge&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
@@ -102,7 +104,9 @@ The following settings, which are provided by external extensions, are honoured 
 
 ## Requirements
 
-These requirements are bundled with Liberty Tools for Visual Studio Code during installation and are provided here for additional information.
+Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+
+The following extensions are bundled with Liberty Tools for Visual Studio Code during installation and are provided here for additional information.
 
 - [Tools for MicroProfile extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile)
 - [XML extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Liberty Tools for Visual Studio Code
 
-> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required to run Liberty Tools for Visual Studio Code.
 
 [![Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Open-Liberty.liberty-dev-vscode-ext?style=for-the-badge&label=VS%20Market "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
 [![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?style=for-the-badge&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
@@ -104,7 +104,7 @@ The following settings, which are provided by external extensions, are honoured 
 
 ## Requirements
 
-Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required.
+> Note: Starting with the [0.1.12 early release](https://github.com/OpenLiberty/liberty-tools-vscode/releases/tag/0.1.12), Java 17 is required to run Liberty Tools for Visual Studio Code.
 
 The following extensions are bundled with Liberty Tools for Visual Studio Code during installation and are provided here for additional information.
 


### PR DESCRIPTION
See https://github.com/kathrynkodama/liberty-dev-vscode-ext/tree/readme-java17#liberty-tools-for-visual-studio-code and https://github.com/kathrynkodama/liberty-dev-vscode-ext/blob/readme-java17/CONTRIBUTING.md#contributing-to-liberty-dev-extension-for-visual-studio-code

Noting that on the next release, the Liberty Tools for VS Code page on the marketplace will reflect the changes made to the README. 