### PR TITLE
Update Liberty Tools and VS Code versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "liberty-dev-vscode-ext",
-	"version": "0.1.13-SNAPSHOT",
+	"version": "23.0.6-SNAPSHOT",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "liberty-dev-vscode-ext",
 	"displayName": "Liberty Tools",
 	"description": "Liberty Tools for Visual Studio Code",
-	"version": "0.1.13-SNAPSHOT",
+	"version": "23.0.6-SNAPSHOT",
 	"publisher": "Open-Liberty",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"preview": true,
 	"license": "EPL-2.0",
 	"engines": {
-		"vscode": "^1.36.0"
+		"vscode": "^1.78.0"
 	},
 	"categories": [
 		"Programming Languages"


### PR DESCRIPTION
Update LT version to 23.0.6-SNAPSHOT
Update VS Code minimum version to 1.78.0