### PR TITLE
#210-fixed the issue Custom Start... command

### DIFF
--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -377,7 +377,8 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
                 promptString = localize("specify.custom.parms.gradle");
             }
 
-
+            // set focus on the Inputbox
+            await vscode.commands.executeCommand( 'workbench.action.focusNextGroup')
 
             // prompt for custom command
             let customCommand: string | undefined = await vscode.window.showInputBox(Object.assign({

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -378,7 +378,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             }
 
             // set focus on the Inputbox
-            await vscode.commands.executeCommand( 'workbench.action.focusNextGroup')
+            await vscode.commands.executeCommand('workbench.action.focusNextGroup');
 
             // prompt for custom command
             let customCommand: string | undefined = await vscode.window.showInputBox(Object.assign({


### PR DESCRIPTION
Fixed the issue - When executing the Liberty: Start... command from the command palette, the focus will redirect out into a terminal window when prompted the custom params.