### PR TITLE
Allow LCLS to handle custom config files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,7 @@ function startLangServer(context: ExtensionContext, requirements: RequirementsDa
 function prepareClientOptions(Liberty_LS :boolean) {
     if (Liberty_LS) {
         return {
-            // Filter to `bootstrap.properties` and `server.env` files within `src/main/liberty/config` or `usr/servers`
+            // Filter to `*.properties` and `*.env` files, let LCLS handle filtering for default/custom configs
             documentSelector: [{ scheme: "file", 
                                 pattern: "**/{*.properties,*.env}" }],
             synchronize: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,12 +213,13 @@ function prepareClientOptions(Liberty_LS :boolean) {
         return {
             // Filter to `bootstrap.properties` and `server.env` files within `src/main/liberty/config` or `usr/servers`
             documentSelector: [{ scheme: "file", 
-                                pattern: "**/{src/main/liberty/config,usr/servers/**}/{bootstrap.properties,server.env}" }],
+                                pattern: "**/{*.properties,*.env}" }],
             synchronize: {
                 configurationSection: SUPPORTED_LANGUAGE_IDS,
                 fileEvents: [
-                    workspace.createFileSystemWatcher("**/bootstrap.properties"),
-                    workspace.createFileSystemWatcher("**/server.env")
+                    workspace.createFileSystemWatcher("**/*.properties"),
+                    workspace.createFileSystemWatcher("**/*.env"),
+                    workspace.createFileSystemWatcher("**/liberty-plugin-config.xml")
                 ],
             }
         };


### PR DESCRIPTION
Client-side changes to support custom config files, enabled in OpenLiberty/liberty-language-server#212
- Send all .properties and .env files to LCLS
- Send fileChange events for .properties, .env, and liberty-plugin-config.xml to LCLS.

Tested that these changes do not affect how it currently works with the existing release of LCLS which does not support custom configs.