### PR TITLE
add support for new jakarta LS/Client message - fileInfo

### DIFF
--- a/src/definitions/lsp4jakartaLSRequestNames.ts
+++ b/src/definitions/lsp4jakartaLSRequestNames.ts
@@ -9,6 +9,7 @@
  */
 
 // Jakarta Language API
+export const FILEINFO_REQUEST = "jakarta/java/fileInfo"
 export const JAVA_HOVER_REQUEST = "jakarta/java/hover";
 export const JAVA_DIAGNOSTICS_REQUEST = "jakarta/java/diagnostics";
 export const JAVA_COMPLETION_REQUEST = "jakarta/java/completion";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             console.log("LSP4Jakarta is ready, binding requests...");
     
             // Delegate requests from Jakarta LS to the Jakarta JDT core
+            bindRequest(lsp4jakartaLS.FILEINFO_REQUEST);
             bindRequest(lsp4jakartaLS.JAVA_COMPLETION_REQUEST);
             bindRequest(lsp4jakartaLS.JAVA_CODEACTION_REQUEST);
 	    bindRequest(lsp4jakartaLS.JAVA_CODEACTION_RESOLVE_REQUEST);


### PR DESCRIPTION
there is a new "jakarta/java/fileInfo" message supported between LS and LSClient to get the package name for the file that is currently having a snippet inserted into it. This was not functioning in the vscode env because the config for that new message was missing from the DelegateCommandHandler and the vscode client config as well. Added this support so that package name can be obtained from the jakarta JDT LS extn. There is a separate PR int he liberty-tools-vscode repo to pick up the tool config side of this.

This PR cannot be merged/built until https://github.com/eclipse/lsp4jakarta/pull/501 is reviewed/merged and a lsp4jakarta snapshot is respun.