### PR TITLE
Fixes for report being created at a new location using the latest surefire plugin 

### DIFF
--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -490,7 +490,6 @@ export async function openReport(reportType: string, libProject?: LibertyProject
         if (path !== undefined) {
             let report: any;
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                //report = Path.join(path, "target", "site", reportType + "-report.html");
                 report = getReportFile(path,"reports",reportType+".html");
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
                 report = await getGradleTestReport(libProject.path, path);
@@ -501,14 +500,14 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             }
             if(libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER){
                 console.log("report path ::"+report)
-                if(!await checkReportExists(report,reportType,reportTypeLabel,libProject)){
+                if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
                     report = getReportFile(path,"site",reportType+"-report.html");
-                    if(!await checkReportExists(report,reportType,reportTypeLabel,libProject)){
+                    if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
                         const message = localize("test.report.does.not.exist.run.test.first", report);
                         vscode.window.showInformationMessage(message);
                     }     
                 }
-            }else if(!await checkReportExists(report,reportType,reportTypeLabel,libProject)){
+            }else if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
                         const message = localize("test.report.does.not.exist.run.test.first", report);
                         vscode.window.showInformationMessage(message);
                     }
@@ -614,8 +613,6 @@ function isWin(): boolean {
 }
 
 function getReportFile(path :any,dir :string,filename:string):any{
-    console.log("inside getReportFile path::"+path+"::dir::"+dir+"::fileName::"+filename);
-    console.log("::path::"+Path.join(path,"target",dir,filename));
     return Path.join(path,"target",dir, filename);
 }
 
@@ -623,7 +620,7 @@ function getReportFile(path :any,dir :string,filename:string):any{
 Function will check if the report is available within the given path and returns a boolean based on it and also 
   the report will be displayed if it is available
 */
-function checkReportExists(report : any,reportType : string,reportTypeLabel: string,libProject :LibertyProject): Promise<boolean> {
+function checkReportAndDisplay(report : any,reportType : string,reportTypeLabel: string,libProject :LibertyProject): Promise<boolean> {
     return new Promise((resolve) => {
       fs.exists(report, (exists) => {
         if(exists){

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -496,10 +496,14 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             let showErrorMessage: boolean = true;
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
                 report = getReportFile(path, "reports", reportType + ".html");
-                showErrorMessage = false; // show the error message only if both "reports" and "site" dirs do not contain the test reports - setting to false since this will be the first location checked
+                // show the error message only if both "reports" and "site" dirs do not contain the test reports
+                // set to false since this will be the first location checked
+                showErrorMessage = false; 
                 if (!await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage)) {
                     report = getReportFile(path, "site", reportType + "-report.html");
-                    showErrorMessage = true; // show the error message only if both "reports" and "site" dirs do not contain the test reports - setting to true since this will be the second location checked
+                    // show the error message only if both "reports" and "site" dirs do not contain the test reports
+                    // set to true since this will be the second location checked
+                    showErrorMessage = true; 
                     await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage);
                 }
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
@@ -630,11 +634,11 @@ function checkReportAndDisplay(report: any, reportType: string, reportTypeLabel:
                 );
                 panel.webview.html = getReport(report); // display HTML content
                 /*
-                For maven projects we need to check for the report in 'reports' and 'site', we only need to show the message if it is not 
-                available in both the locations, below condition make sure to avoid the message when its a maven project and the directory 
-                is 'reports'
+                For Maven projects we need to check for the test report in the 'reports' and 'site' dirs. 
+                We only need to show the message if it is not available in both locations. 
+                The `showErrorMessage` flag will only be set to true when checking the second location.
                 */
-            } else if (showErrorMessage) { // If it is flagged to show the error message, then show it. Otherwise do not show it.
+            } else if (showErrorMessage) {
                 const message = localize("test.report.does.not.exist.run.test.first", report);
                 vscode.window.showInformationMessage(message);
             }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -130,7 +130,7 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
 
 export async function removeProject(): Promise<void> {
     const projectProvider: ProjectProvider = ProjectProvider.getInstance();
-
+    
     // clicked on the empty space and workspace has more than one folders, or
     // from command palette
     // Display the list of current user added projects for user to select.
@@ -163,7 +163,7 @@ export async function removeProject(): Promise<void> {
                     }
                 });
         });
-
+        
     }
 }
 
@@ -507,7 +507,6 @@ export async function openReport(reportType: string, libProject?: LibertyProject
                 await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage);
             }
 
-
         }
     } else if (ProjectProvider.getInstance() && reportType) {
         showProjects(reportType, openReport, reportType);
@@ -637,7 +636,6 @@ function checkReportAndDisplay(report: any, reportType: string, reportTypeLabel:
                 is 'reports'
                 */
             } else if (showErrorMessage) {// if it is flagged to show the error message then show it else dont
-
                 const message = localize("test.report.does.not.exist.run.test.first", report);
                 vscode.window.showInformationMessage(message);
             }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -496,17 +496,16 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             let showErrorMessage: boolean = true;
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
                 report = getReportFile(path, "reports", reportType + ".html");
-                showErrorMessage = false; // show the error message only if the directory is not reports, so setting to false
+                showErrorMessage = false; // show the error message only if both "reports" and "site" dirs do not contain the test reports - setting to false since this will be the first location checked
                 if (!await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage)) {
                     report = getReportFile(path, "site", reportType + "-report.html");
-                    showErrorMessage = true;//report is not available in 'reports', hence show the message if report is not availabe in 'site', so setting to true
+                    showErrorMessage = true; // show the error message only if both "reports" and "site" dirs do not contain the test reports - setting to true since this will be the second location checked
                     await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage);
                 }
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
                 report = await getGradleTestReport(libProject.path, path);
                 await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject, showErrorMessage);
             }
-
         }
     } else if (ProjectProvider.getInstance() && reportType) {
         showProjects(reportType, openReport, reportType);
@@ -635,7 +634,7 @@ function checkReportAndDisplay(report: any, reportType: string, reportTypeLabel:
                 available in both the locations, below condition make sure to avoid the message when its a maven project and the directory 
                 is 'reports'
                 */
-            } else if (showErrorMessage) {// if it is flagged to show the error message then show it else dont
+            } else if (showErrorMessage) { // If it is flagged to show the error message, then show it. Otherwise do not show it.
                 const message = localize("test.report.does.not.exist.run.test.first", report);
                 vscode.window.showInformationMessage(message);
             }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -498,6 +498,10 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             if (reportType === "gradle") {
                 reportTypeLabel = "test";
             }
+            /*
+            if its a maven project, check for the report in the initial path , else try for the alternate one and if it doesnt exist in both 
+            display a prompt for its non existance
+            */
             if(libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER){
                 console.log("report path ::"+report)
                 if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
@@ -507,6 +511,9 @@ export async function openReport(reportType: string, libProject?: LibertyProject
                         vscode.window.showInformationMessage(message);
                     }     
                 }
+            /*
+            if its a gralde project, then check existance for the report in the path set and if not display prompt for its non existance
+            */
             }else if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
                         const message = localize("test.report.does.not.exist.run.test.first", report);
                         vscode.window.showInformationMessage(message);
@@ -612,6 +619,10 @@ function isWin(): boolean {
     return process.platform.startsWith("win");
 }
 
+/*
+will return the path of the report, since there are diffrent folders to look into and the file names can be different 
+we need to get the paths to look for dynamically
+*/
 function getReportFile(path :any,dir :string,filename:string):any{
     return Path.join(path,"target",dir, filename);
 }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -77,17 +77,18 @@ export async function openProject(pomPath: string): Promise<void> {
 export async function listAllCommands(): Promise<void> {
     const libertyCommands = Array.from(COMMAND_TITLES.keys());
     vscode.window.showQuickPick(libertyCommands).then(selection => {
-        if (!selection) {
-            return;
-        }
-        const command = COMMAND_TITLES.get(selection);
-        if (command !== undefined) {
-            vscode.commands.executeCommand(command);
-        } else {
-            // should never happen
-            console.error("Unable to find corresponding command for " + selection);
-        }
-
+            if (!selection) {
+                return;
+            }
+            const command = COMMAND_TITLES.get(selection);
+            if ( command !== undefined )
+            {
+                vscode.commands.executeCommand(command);
+            } else {
+                // should never happen
+                console.error("Unable to find corresponding command for " + selection);
+            }
+                
     });
 }
 
@@ -192,11 +193,11 @@ export async function addProject(uri: vscode.Uri): Promise<void> {
         // scan the folder and get a list of folders with pom.xml and build.gradle
         const uris: string[] = await projectProvider.getListOfMavenAndGradleFolders(uri.fsPath);
         console.log(JSON.stringify(uris));
-        if (uris.length > 0) {
+        if ( uris.length > 0) {
             // present the list to add
             showListOfPathsToAdd(uris);
         }
-
+        
 
     } else {
         // clicked on the empty space and workspace has more than one folders, or
@@ -398,7 +399,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             if (customCommand !== undefined) {
                 // save command
                 customCommand = customCommand.trim();
-                if (customCommand.length > 0) {
+                if ( customCommand.length > 0 ) {
                     const projectStartCmdParam: ProjectStartCmdParam = new ProjectStartCmdParam(libProject.getPath(), customCommand);
                     const projectProvider: ProjectProvider = ProjectProvider.getInstance();
                     const dashboardData: DashboardData = helperUtil.getStorageData(projectProvider.getContext());

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -490,7 +490,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
         if (path !== undefined) {
             let report: any;
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                report = getReportFile(path,"reports",reportType+".html");
+                report = getReportFile(path, "reports", reportType + ".html");
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
                 report = await getGradleTestReport(libProject.path, path);
             }
@@ -504,9 +504,9 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             */
             if(libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER){
                 console.log("report path ::"+report)
-                if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
-                    report = getReportFile(path,"site",reportType+"-report.html");
-                    if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
+                if(!await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject)){
+                    report = getReportFile(path, "site", reportType + "-report.html");
+                    if(!await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject)){
                         const message = localize("test.report.does.not.exist.run.test.first", report);
                         vscode.window.showInformationMessage(message);
                     }     
@@ -514,7 +514,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             /*
             if its a gralde project, then check existance for the report in the path set and if not display prompt for its non existance
             */
-            }else if(!await checkReportAndDisplay(report,reportType,reportTypeLabel,libProject)){
+            }else if(!await checkReportAndDisplay(report, reportType, reportTypeLabel, libProject)){
                         const message = localize("test.report.does.not.exist.run.test.first", report);
                         vscode.window.showInformationMessage(message);
                     }
@@ -623,15 +623,15 @@ function isWin(): boolean {
 will return the path of the report, since there are diffrent folders to look into and the file names can be different 
 we need to get the paths to look for dynamically
 */
-function getReportFile(path :any,dir :string,filename:string):any{
-    return Path.join(path,"target",dir, filename);
+function getReportFile(path : any, dir : string, filename : string) : any{
+    return Path.join(path, "target", dir, filename);
 }
 
 /*
 Function will check if the report is available within the given path and returns a boolean based on it and also 
   the report will be displayed if it is available
 */
-function checkReportAndDisplay(report : any,reportType : string,reportTypeLabel: string,libProject :LibertyProject): Promise<boolean> {
+function checkReportAndDisplay(report : any, reportType : string, reportTypeLabel : string, libProject : LibertyProject) : Promise<boolean> {
     return new Promise((resolve) => {
       fs.exists(report, (exists) => {
         if(exists){

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -102,7 +102,7 @@ it('start maven with options from liberty dashboard', async () => {
   const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html"); // new path to scan for the reports 
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport || deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
+  expect (deleteReport && deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  
@@ -135,7 +135,7 @@ it('start maven with history from liberty dashboard', async () => {
   const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html");
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport || deleteAlternateReport).to.be.true;  
+  expect (deleteReport && deleteAlternateReport).to.be.true;  
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);  
   const foundCommand = await utils.chooseCmdFromHistory("-DhotTests=true");
   expect (foundCommand).to.be.true;  

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -99,10 +99,10 @@ it('Run tests for sample maven project', async () => {
 it('start maven with options from liberty dashboard', async () => {      
     
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const reportPath35 = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
   let deleteReport = await utils.deleteReports(reportPath);
-  let deleteReport35 = await utils.deleteReports(reportPath35);
-  expect (deleteReport||deleteReport35).to.be.true;
+  let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
+  expect (deleteReport||deleteAlternateReport).to.be.true;
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  
@@ -113,8 +113,8 @@ it('start maven with options from liberty dashboard', async () => {
   {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
-    let checkFile35 = await utils.checkIfTestReportExists(reportPath35);
-    expect (checkFile || checkFile35).to.be.true;
+    let checkAlternateFile = await utils.checkIfTestReportExists(alternateReportPath);
+    expect (checkFile || checkAlternateFile).to.be.true;
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 
@@ -132,10 +132,10 @@ it('start maven with options from liberty dashboard', async () => {
 it('start maven with history from liberty dashboard', async () => {  
 
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const reportPath35 = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
   let deleteReport = await utils.deleteReports(reportPath);
-  let deleteReport35 = await utils.deleteReports(reportPath35);
-  expect (deleteReport || deleteReport35).to.be.true;  
+  let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
+  expect (deleteReport || deleteAlternateReport).to.be.true;  
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);  
   const foundCommand = await utils.chooseCmdFromHistory("-DhotTests=true");
   expect (foundCommand).to.be.true;  
@@ -147,8 +147,8 @@ it('start maven with history from liberty dashboard', async () => {
   {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
-    let checkFile35 = await utils.checkIfTestReportExists(reportPath35);
-    expect (checkFile || checkFile35).to.be.true;
+    let checkAlternateFile = await utils.checkIfTestReportExists(alternateReportPath);
+    expect (checkFile || checkAlternateFile).to.be.true;
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -102,7 +102,7 @@ it('start maven with options from liberty dashboard', async () => {
   const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html"); // new path to scan for the reports 
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport && deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
+  expect (deleteReport && deleteAlternateReport).to.be.true; // both report files should either not exist or be successfully deleted
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  
@@ -114,7 +114,7 @@ it('start maven with options from liberty dashboard', async () => {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
     let checkAlternateFile = await utils.checkIfTestReportExists(alternateReportPath);
-    expect (checkFile || checkAlternateFile).to.be.true;
+    expect (checkFile || checkAlternateFile).to.be.true; // check both potential locations for the test report, one of them must exist
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 
@@ -135,7 +135,7 @@ it('start maven with history from liberty dashboard', async () => {
   const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html");
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport && deleteAlternateReport).to.be.true;  
+  expect (deleteReport && deleteAlternateReport).to.be.true;  // both report files should either not exist or be successfully deleted
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);  
   const foundCommand = await utils.chooseCmdFromHistory("-DhotTests=true");
   expect (foundCommand).to.be.true;  
@@ -148,7 +148,7 @@ it('start maven with history from liberty dashboard', async () => {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
     let checkAlternateFile = await utils.checkIfTestReportExists(alternateReportPath);
-    expect (checkFile || checkAlternateFile).to.be.true;
+    expect (checkFile || checkAlternateFile).to.be.true; // check both potential locations for the test report, one of them must exist
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -99,10 +99,10 @@ it('Run tests for sample maven project', async () => {
 it('start maven with options from liberty dashboard', async () => {      
     
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html"); // new path to scan for the reports 
+  const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html"); // new path to scan for the reports 
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport||deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
+  expect (deleteReport || deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  
@@ -132,7 +132,7 @@ it('start maven with options from liberty dashboard', async () => {
 it('start maven with history from liberty dashboard', async () => {  
 
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  const alternateReportPath = path.join(utils.getMvnProjectPath(), "target", "reports", "failsafe.html");
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
   expect (deleteReport || deleteAlternateReport).to.be.true;  

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -99,10 +99,10 @@ it('Run tests for sample maven project', async () => {
 it('start maven with options from liberty dashboard', async () => {      
     
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  const alternateReportPath = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html"); // new path to scan for the reports 
   let deleteReport = await utils.deleteReports(reportPath);
   let deleteAlternateReport = await utils.deleteReports(alternateReportPath);
-  expect (deleteReport||deleteAlternateReport).to.be.true;
+  expect (deleteReport||deleteAlternateReport).to.be.true; // there should be a report available irrespective of the surefire versions we use , so either one needs to be true 
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -97,8 +97,10 @@ it('Run tests for sample maven project', async () => {
 it('start maven with options from liberty dashboard', async () => {      
     
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const deleteReport = await utils.deleteReports(reportPath);
-  expect (deleteReport).to.be.true;
+  const reportPath35 = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  let deleteReport = await utils.deleteReports(reportPath);
+  let deleteReport35 = await utils.deleteReports(reportPath35);
+  expect (deleteReport||deleteReport35).to.be.true;
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);
   await utils.setCustomParameter("-DhotTests=true");  
   await utils.delay(30000);  
@@ -109,7 +111,8 @@ it('start maven with options from liberty dashboard', async () => {
   {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
-    expect (checkFile).to.be.true;
+    let checkFile35 = await utils.checkIfTestReportExists(reportPath35);
+    expect (checkFile || checkFile35).to.be.true;
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 
@@ -127,8 +130,10 @@ it('start maven with options from liberty dashboard', async () => {
 it('start maven with history from liberty dashboard', async () => {  
 
   const reportPath = path.join(utils.getMvnProjectPath(),"target","site","failsafe-report.html");
-  const deleteReport = await utils.deleteReports(reportPath);
-  expect (deleteReport).to.be.true;  
+  const reportPath35 = path.join(utils.getMvnProjectPath(),"target","reports","failsafe.html");
+  let deleteReport = await utils.deleteReports(reportPath);
+  let deleteReport35 = await utils.deleteReports(reportPath35);
+  expect (deleteReport || deleteReport35).to.be.true;  
   await utils.launchDashboardAction(item, constants.START_DASHBOARD_ACTION_WITH_PARAM, constants.START_DASHBOARD_MAC_ACTION_WITH_PARAM);  
   const foundCommand = await utils.chooseCmdFromHistory("-DhotTests=true");
   expect (foundCommand).to.be.true;  
@@ -140,7 +145,8 @@ it('start maven with history from liberty dashboard', async () => {
   {
     console.log("Server succuessfully started");  
     let checkFile = await utils.checkIfTestReportExists(reportPath);
-    expect (checkFile).to.be.true;
+    let checkFile35 = await utils.checkIfTestReportExists(reportPath35);
+    expect (checkFile || checkFile35).to.be.true;
     await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);    
     const serverStopStatus= await utils.checkTerminalforServerState(constants.SERVER_STOP_STRING);
     if(!serverStopStatus){ 


### PR DESCRIPTION
Fixes #340  , Fixes for report being created at a new location using the latest surefire plugin, now this checks the previous location as well as the new location for reports, also included test test cases for considering the new locations 