### PR TITLE
Fix for gradle wrapper command - Project path with space

### DIFF
--- a/src/util/commandUtils.ts
+++ b/src/util/commandUtils.ts
@@ -60,7 +60,7 @@ export async function getCommandForGradle(buildGradlePath: string, command: stri
         return getGradleCommandForWin(gradleCmdStart, buildGradlePath, command, terminalType, customCommand);
     } else {
         gradleCmdStart = Path.join(gradleCmdStart, "gradlew");
-        return formDefaultCommand(gradleCmdStart, buildGradlePath, command, "-b=", customCommand);
+        return formDefaultCommandWithPath(gradleCmdStart, buildGradlePath, command, "-b=", customCommand);
     }
 }
 


### PR DESCRIPTION
Fixes #399 
Fix added for the command executing using gradle wrapper in mac