### PR TITLE
issue-445 - control auto-refresh behaviour with a settings property

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,12 @@
 						"default": false,
 						"description": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
 						"scope": "window"
+					},
+					"liberty.refresh.enabled": {
+						"type": "boolean",
+						"default": true,
+						"description": "If this value is false the extension will not try to refresh the liberty dashboard upon changes in the workspace.",
+						"scope": "window"
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,9 +106,12 @@ function bindRequest(request: string) {
 
 function registerCommands(context: ExtensionContext) {
     let projectProvider = getProjectProvider(context);
+    const refreshEnabled: any = helperUtil.getConfiguration("refresh.enabled");
 
-    if (vscode.workspace.workspaceFolders !== undefined) {
-        registerFileWatcher(projectProvider);
+    if (vscode.workspace.workspaceFolders !== undefined) {    
+        if(refreshEnabled) {
+            registerFileWatcher(projectProvider);
+        }
         vscode.window.registerTreeDataProvider("liberty-dev", projectProvider);
     }
 
@@ -163,9 +166,11 @@ function registerCommands(context: ExtensionContext) {
         })
     );
      // Listens for any new folders are added to the workspace
-     context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => {
-        projectProvider.refresh();
-    }));
+     if(refreshEnabled) {
+        context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => {
+            projectProvider.refresh();
+        }));
+     }
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
add a setting property "liberty.refresh.enabled" to control the automatic refresh of the liberty dashboard. 

issue https://github.com/OpenLiberty/liberty-tools-vscode/issues/455