### PR TITLE
Fixed windows build failure issue and enabled windows GHA build

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -8,26 +8,44 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ linux, mac ]
+        runtime: [ linux, mac, windows ]
+        include:
+          - runtime: linux
+            os: ubuntu-latest
+            reportName: linux-test-report
+          - runtime: mac
+            os: macOS-latest
+            reportName: mac-test-report
+          - runtime: windows
+            os: windows-latest
+            reportName: windows-test-report
+
+# jobs:
+#   build:
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         runtime: [ linux, mac, windows ]
      # Removing windows as a standard run flavor   runtime: [ linux, mac, windows ]
-        targetVSCode: [previous, latest ]
+        # targetVSCode: [previous, latest ]
       # As Vscode 1.79 and 1.78 are  the only support version for current release, running test with only latest,previous
       #Enable it in future for multiple releases as applicable  targetVSCode: [ previousMinusOne, previous, latest ]
-        include:
-        - runtime: linux
-          os: ubuntu-latest
+        # include:
+        # - runtime: linux
+        #   os: ubuntu-latest
 
-        - runtime: mac
-          os: macOS-13
+        # - runtime: mac
+        #   os: macOS-13
 
-        - runtime: windows
-          os: windows-latest
+        # - runtime: windows
+        #   os: windows-latest
 
-    name: Build Plugin
-    runs-on: ${{ matrix.os }}
+    # name: Build Plugin
+    # runs-on: ${{ matrix.os }}
 
     steps:
       # Checkout the eclipse plugin repository.

--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -23,8 +23,8 @@ jobs:
         - runtime: mac
           os: macOS-13
 
-      #  - runtime: windows
-      #    os: windows-latest
+        - runtime: windows
+          os: windows-latest
 
     name: Build Plugin
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"mocha": "^9.2.2",
 				"ts-loader": "^9.3.1",
 				"typescript": "^4.8.4",
-				"vscode-extension-tester": "^7.3.0",
+				"vscode-extension-tester": "^8.10.0",
 				"vscode-test": "^1.3.0",
 				"webpack": "^5.96.1",
 				"webpack-cli": "^4.10.0"

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
 		"mocha": "^9.2.2",
 		"ts-loader": "^9.3.1",
 		"typescript": "^4.8.4",
-		"vscode-extension-tester": "^7.3.0",
+		"vscode-extension-tester": "^8.10.0",
 		"vscode-test": "^1.3.0",
 		"webpack": "^5.96.1",
 		"webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
 		"gulp-download2": "^1.1.0",
 		"mocha": "^9.2.2",
 		"ts-loader": "^9.3.1",
-		"typescript": "^4.8.4",
+		"typescript": "^5.7.2",
 		"vscode-extension-tester": "^8.10.0",
 		"vscode-test": "^1.3.0",
 		"webpack": "^5.96.1",


### PR DESCRIPTION
Fixes #265 and #451 

To fix the windows build failure in GHA updated the vscode extension tester framework to latest. 