### PR TITLE
Using single command to run test in GHA for all OS

### DIFF
--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -62,27 +62,10 @@ main() {
 
         if [ $VSCODE_VERSION_TO_RUN == "latest" ]; then
             # Run the plugin's install goal against the latest vscode version
-             if [ $OS = "Darwin" ]; then
-                chown -R runner src/test/resources/maven
-              chown -R runner  src/test/resources/gradle
-                # Gradle tests should be run before Maven tests because the after hook for copying the screeshots from temporary to a  permananet location is written in the Maven tests so that the copying will be done at the end of every test cases.
-                npm run test-mac-gradle -- -u
-                npm run test-mac-maven -- -u
-            else
-                npm run test -- -u
-            fi
+            npm run test -- -u
         else
             # Run the plugin's install goal against the target vscode version
-            if [ $OS = "Darwin" ]; then
-              chown -R runner src/test/resources/maven
-              chown -R runner  src/test/resources/gradle
-              # Gradle tests should be run before Maven tests because the after hook for copying the screeshots from temporary to a  permananet location is written in the Maven tests so that the copying will be done at the end of every test cases.
-              npm run test-mac-gradle -- -u -c $VSCODE_VERSION_TO_RUN
-              npm run test-mac-maven -- -u -c $VSCODE_VERSION_TO_RUN
-
-            else
             npm run test -- -u -c $VSCODE_VERSION_TO_RUN
-            fi
         fi
     fi
 


### PR DESCRIPTION
Updated the execution file such that all the tests are run using a single command in GHA for all OS.

Fixes #486 