### PR TITLE
Issue 481 - Green Builds Showing Despite Test Failures

### DIFF
--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -97,7 +97,7 @@ main() {
 
     # If there were any errors, gather some debug data before exiting.
     if [ "$failure" = "true" ]; then
-        echo "ERROR: Failure occurred while running the tests."
+        echo "ERROR: Failure occurred while running ${TYPE} step."
 
         if [ $TYPE = "TEST" ]; then
             echo "DEBUG: Maven Liberty messages.log:\n"

--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -96,9 +96,8 @@ main() {
     fi
 
     # If there were any errors, gather some debug data before exiting.
-    rc=$?
-    if [ "$rc" -ne 0 ]; then
-        echo "ERROR: Failure while driving npm install on plugin. rc: ${rc}."
+    if [ "$failure" = "true" ]; then
+        echo "ERROR: Failure occurred while running the tests."
 
         if [ $TYPE = "TEST" ]; then
             echo "DEBUG: Maven Liberty messages.log:\n"

--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -26,6 +26,9 @@ currentTime=(date +"%Y/%m/%d-%H:%M:%S:%3N")
 # Operating system.
 OS=$(uname -s)
 
+# Boolean to see if any failure has occured while executing commands
+failure="false"
+
 main() {
 
     setVscodeVersionToTest
@@ -150,6 +153,15 @@ setVscodeVersionToTest() {
         else
                 VSCODE_VERSION_TO_RUN="$previousMinusOne.0"
         fi
+}
+
+# Finding the exit status of a command and updating failure boolean.
+# Need to call this method after executing each npm command to store the status.
+updateExitStatus() {
+    status=$?
+    if [ "$failure" = "false" ] && [ $status -ne 0 ]; then
+        failure="true"
+    fi
 }
 
 main "$@"

--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -43,6 +43,7 @@ main() {
         npm run build
         npm run compile
         vsce package
+        updateExitStatus
     else
 
         #Initialisation step
@@ -70,9 +71,12 @@ main() {
               chown -R runner  src/test/resources/gradle
                 # Gradle tests should be run before Maven tests because the after hook for copying the screeshots from temporary to a  permananet location is written in the Maven tests so that the copying will be done at the end of every test cases.
                 npm run test-mac-gradle -- -u
+                updateExitStatus
                 npm run test-mac-maven -- -u
+                updateExitStatus
             else
                 npm run test -- -u
+                updateExitStatus
             fi
         else
             # Run the plugin's install goal against the target vscode version
@@ -81,10 +85,12 @@ main() {
               chown -R runner  src/test/resources/gradle
               # Gradle tests should be run before Maven tests because the after hook for copying the screeshots from temporary to a  permananet location is written in the Maven tests so that the copying will be done at the end of every test cases.
               npm run test-mac-gradle -- -u -c $VSCODE_VERSION_TO_RUN
+              updateExitStatus
               npm run test-mac-maven -- -u -c $VSCODE_VERSION_TO_RUN
-
+              updateExitStatus
             else
             npm run test -- -u -c $VSCODE_VERSION_TO_RUN
+            updateExitStatus
             fi
         fi
     fi


### PR DESCRIPTION
Fixes #481 
Added method to fetch the status of previous command and update a boolean flag to see if the build is a failure or not.

Refer PR https://github.com/OpenLiberty/liberty-tools-vscode/pull/487 for more details.