### PR TITLE
Updated LSP4Jakarta 0.2.3 releases

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ const cp = require("child_process");
 const libertyGroupId = "io.openliberty.tools";
 const libertyVersion = "2.2";
 const jakartaGroupId = "org.eclipse.lsp4jakarta";
-const jakartaVersion = "0.2.2";
+const jakartaVersion = "0.2.3";
 var releaseLevel = "releases";  //"snapshots"; //snapshots or releases
 
 const libertyLemminxName = "liberty-langserver-lemminx-" + libertyVersion + "-jar-with-dependencies.jar";

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 	],
 	"contributes": {
 		"javaExtensions": [
-			"./jars/org.eclipse.lsp4jakarta.jdt.core-0.2.2.jar"
+			"./jars/org.eclipse.lsp4jakarta.jdt.core-0.2.3.jar"
 		],
 		"xml.javaExtensions": [
 			"./jars/liberty-langserver-lemminx-2.2-jar-with-dependencies.jar"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import * as helperUtil from "./util/helperUtil";
 const LIBERTY_CLIENT_ID = "LANGUAGE_ID_LIBERTY";
 const JAKARTA_CLIENT_ID = "LANGUAGE_ID_JAKARTA";
 export const LIBERTY_LS_JAR = "liberty-langserver-2.2-jar-with-dependencies.jar";
-export const JAKARTA_LS_JAR = "org.eclipse.lsp4jakarta.ls-0.2.2-jar-with-dependencies.jar";
+export const JAKARTA_LS_JAR = "org.eclipse.lsp4jakarta.ls-0.2.3-jar-with-dependencies.jar";
 
 let libertyClient: LanguageClient;
 let jakartaClient: LanguageClient;


### PR DESCRIPTION
Fixes #524 
Updated LSP4Jakarta 0.2.3 releases.
Tested the plugin and verified the [issue#389](https://github.com/OpenLiberty/liberty-tools-vscode/issues/389) with the new release version, and it is working as expected.