### PR TITLE
fixes the refresh issue  when build files are generated in build directories

### DIFF
--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,7 +32,7 @@ export const COMMAND_AND_PROJECT_TYPE_MAP: { [command: string]: string[] } = {
     "gradle":[ LIBERTY_GRADLE_PROJECT, LIBERTY_GRADLE_PROJECT_CONTAINER],
     "liberty.dev.debug": [LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
 };
-export const EXCLUDED_DIR_PATTERN = "**/{bin,classes,target}/**";
+export const EXCLUDED_DIR_PATTERN = "**/{bin,classes,target,build}/**";
 export const COMMAND_TITLES = new Map();
 export const UNTITLED_WORKSPACE="Untitled (Workspace)";
 COMMAND_TITLES.set(localize("hotkey.commands.title.refresh"), "liberty.explorer.refresh");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { localize } from "./util/i18nUtil";
 import { RequirementsData, resolveRequirements, resolveLclsRequirements } from "./util/requirements";
 import { prepareExecutable } from "./util/javaServerStarter";
 import * as helperUtil from "./util/helperUtil";
+import path = require('path');
 
 const LIBERTY_CLIENT_ID = "LANGUAGE_ID_LIBERTY";
 const JAKARTA_CLIENT_ID = "LANGUAGE_ID_JAKARTA";
@@ -184,15 +185,49 @@ export function deactivate(): Promise<void[]> {
  */
 export function registerFileWatcher(projectProvider: ProjectProvider): void {
 	const watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("{**/pom.xml,**/build.gradle,**/settings.gradle,**/src/main/liberty/config/server.xml}");
-	watcher.onDidCreate(async () => {
-		projectProvider.refresh();
-	});
-	watcher.onDidChange(async () => {
-		projectProvider.refresh();
-	});
-	watcher.onDidDelete(async () => {
-		projectProvider.refresh();
-	});
+	    // Async handler for the file system events (create, change, delete)
+        const handleUri = async (uri: vscode.Uri) => {
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+    
+            if (!workspaceFolders) {
+                return; // No workspace folders to process
+            }
+    
+            // Loop through all workspace folders
+            for (let folder of workspaceFolders) {
+                const projectRoot = folder.uri.fsPath;
+                const relativePath = path.relative(projectRoot, uri.fsPath);
+    
+                // Ensure that the file belongs to this project (starts with the projectRoot path)
+                if (!uri.fsPath.startsWith(projectRoot)) {
+                    continue; // Skip if the file is outside the current project folder
+                }
+    
+                // Check if the path includes 'target' or 'build' directly under the project root
+                if (/(target\/|build\/)/.test(relativePath)) { 
+
+                    const fileType = path.basename(uri.fsPath);
+                    const siblingFileExists = await helperUtil.checkSiblingFilesInTargetOrBuildParent(uri.fsPath);
+                    if(!siblingFileExists){
+                        console.log(`No sibling ${fileType} found, refreshing project... for  ` + uri.fsPath);
+                        // Refresh the project if no sibling file is found
+                        await projectProvider.refresh();
+                    }else{
+                        console.log(`Skipping refresh: Sibling ${fileType} found for `+uri.fsPath);
+                        return; // Do not refresh
+                    }
+                } else {
+                    // If the file generated is **outside** the `target` directory, always refresh
+                    console.log('Refreshing project...');
+                    await projectProvider.refresh();
+                }
+           }
+        };
+    
+    
+        watcher.onDidCreate(handleUri);
+        watcher.onDidChange(handleUri);
+        watcher.onDidDelete(handleUri);
 }
 
 function startLangServer(context: ExtensionContext, requirements: RequirementsData, isLiberty: boolean) {

--- a/src/util/helperUtil.ts
+++ b/src/util/helperUtil.ts
@@ -13,6 +13,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 import { LibertyProject } from "./../liberty/libertyProject";
 import { COMMAND_AND_PROJECT_TYPE_MAP, LIBERTY_DASHBOARD_WORKSPACE_STORAGE_KEY } from "../definitions/constants";
+import path = require('path');
 
 
 export async function getAllPaths(projectRootPath: string, pattern: string): Promise<string[]> {
@@ -78,5 +79,62 @@ export async function saveStorageData(context: vscode.ExtensionContext, dasboard
 export function clearDataSavedInGlobalState(context: vscode.ExtensionContext) {
 	context.globalState.update('workspaceSaveInProgress', false);
 	context.globalState.update('selectedProject', undefined);
+}
+
+/**
+ * Traverse upwards to check for target/build directory and its corresponding sibling build file (pom.xml or build.gradle).
+ * @param filePath The file path to start the search from.
+ * @returns true if sibling file found, false otherwise.
+ */
+export async function checkSiblingFilesInTargetOrBuildParent(filePath: string): Promise<boolean> {
+
+    try {
+        let currentDir = path.dirname(filePath);  // Start with the directory of the provided file
+
+        // Traverse upwards through the directories
+        while (currentDir !== path.parse(currentDir).root) {
+            let targetDir: string | undefined;
+            let siblingFilePath: string | undefined;
+
+            // Determine the file type to look for (either pom.xml or build.gradle)
+            if (filePath.endsWith('pom.xml')) {
+                targetDir = 'target';  // For Maven projects, look for target directory
+                siblingFilePath = path.join(currentDir, targetDir, 'pom.xml');
+            } else if (filePath.endsWith('build.gradle') || filePath.endsWith('settings.gradle')) {
+                targetDir = 'build';  // For Gradle projects, look for build directory
+                siblingFilePath = path.join(currentDir, targetDir, 'build.gradle');
+            } else {
+                console.log("Invalid file type. Only 'pom.xml' or 'build.gradle' are supported.");
+                return false;
+            }
+
+            // Ensure that targetDir and siblingFilePath are assigned before proceeding
+            if (!targetDir || !siblingFilePath) {
+                console.error("Error: targetDir or siblingFilePath not properly assigned.");
+                return false;
+            }
+
+            // Check if the target/build directory exists
+            const currentTargetDir = path.join(currentDir, targetDir);
+            if (fs.existsSync(currentTargetDir) && fs.statSync(currentTargetDir).isDirectory()) {
+
+                // Check if the expected sibling file (pom.xml or build.gradle) exists
+                if (fs.existsSync(siblingFilePath) && fs.statSync(siblingFilePath).isFile()) {
+                    console.log(`Found sibling ${filePath.endsWith('pom.xml') ? 'pom.xml' : 'build.gradle'} in directory: ${currentTargetDir}`);
+                    return true; // Found the sibling file, return true to indicate file should be ignored
+                }
+            }
+
+            // Move up to the parent directory
+            currentDir = path.dirname(currentDir);
+        }
+
+        // If no sibling file was found and we reached the root, return false to allow refresh
+        console.log("Reached project root, no sibling file found. Allowing refresh.");
+        return false;
+    } catch (err) {
+        console.error('Error during directory traversal:', err);
+        return false;
+    }
 }
 

--- a/src/util/helperUtil.ts
+++ b/src/util/helperUtil.ts
@@ -88,53 +88,53 @@ export function clearDataSavedInGlobalState(context: vscode.ExtensionContext) {
  */
 export async function checkSiblingFilesInTargetOrBuildParent(filePath: string): Promise<boolean> {
 
-    try {
-        let currentDir = path.dirname(filePath);  // Start with the directory of the provided file
+	try {
+		let currentDir = path.dirname(filePath);  // Start with the directory of the provided file
 
-        // Traverse upwards through the directories
-        while (currentDir !== path.parse(currentDir).root) {
-            let targetDir: string | undefined;
-            let siblingFilePath: string | undefined;
+		// Traverse upwards through the directories
+		while (currentDir !== path.parse(currentDir).root) {
+			let targetDir: string | undefined;
+			let siblingFilePath: string | undefined;
 
-            // Determine the file type to look for (either pom.xml or build.gradle)
-            if (filePath.endsWith('pom.xml')) {
-                targetDir = 'target';  // For Maven projects, look for target directory
-                siblingFilePath = path.join(currentDir, targetDir, 'pom.xml');
-            } else if (filePath.endsWith('build.gradle') || filePath.endsWith('settings.gradle')) {
-                targetDir = 'build';  // For Gradle projects, look for build directory
-                siblingFilePath = path.join(currentDir, targetDir, 'build.gradle');
-            } else {
-                console.log("Invalid file type. Only 'pom.xml' or 'build.gradle' are supported.");
-                return false;
-            }
+			// Determine the file type to look for (either pom.xml or build.gradle)
+			if (filePath.endsWith('pom.xml')) {
+				targetDir = 'target';  // For Maven projects, look for target directory
+				siblingFilePath = path.join(currentDir, targetDir, 'pom.xml');
+			} else if (filePath.endsWith('build.gradle') || filePath.endsWith('settings.gradle')) {
+				targetDir = 'build';  // For Gradle projects, look for build directory
+				siblingFilePath = path.join(currentDir, targetDir, 'build.gradle');
+			} else {
+				console.log("Invalid file type. Only 'pom.xml' or 'build.gradle' are supported.");
+				return false;
+			}
 
-            // Ensure that targetDir and siblingFilePath are assigned before proceeding
-            if (!targetDir || !siblingFilePath) {
-                console.error("Error: targetDir or siblingFilePath not properly assigned.");
-                return false;
-            }
+			// Ensure that targetDir and siblingFilePath are assigned before proceeding
+			if (!targetDir || !siblingFilePath) {
+				console.error("Error: targetDir or siblingFilePath not properly assigned.");
+				return false;
+			}
 
-            // Check if the target/build directory exists
-            const currentTargetDir = path.join(currentDir, targetDir);
-            if (fs.existsSync(currentTargetDir) && fs.statSync(currentTargetDir).isDirectory()) {
+			// Check if the target/build directory exists
+			const currentTargetDir = path.join(currentDir, targetDir);
+			if (fs.existsSync(currentTargetDir) && fs.statSync(currentTargetDir).isDirectory()) {
 
-                // Check if the expected sibling file (pom.xml or build.gradle) exists
-                if (fs.existsSync(siblingFilePath) && fs.statSync(siblingFilePath).isFile()) {
-                    console.log(`Found sibling ${filePath.endsWith('pom.xml') ? 'pom.xml' : 'build.gradle'} in directory: ${currentTargetDir}`);
-                    return true; // Found the sibling file, return true to indicate file should be ignored
-                }
-            }
+				// Check if the expected sibling file (pom.xml or build.gradle) exists
+				if (fs.existsSync(siblingFilePath) && fs.statSync(siblingFilePath).isFile()) {
+					console.log(`Found sibling ${filePath.endsWith('pom.xml') ? 'pom.xml' : 'build.gradle'} in directory: ${currentTargetDir}`);
+					return true; // Found the sibling file, return true to indicate file should be ignored
+				}
+			}
 
-            // Move up to the parent directory
-            currentDir = path.dirname(currentDir);
-        }
+			// Move up to the parent directory
+			currentDir = path.dirname(currentDir);
+		}
 
-        // If no sibling file was found and we reached the root, return false to allow refresh
-        console.log("Reached project root, no sibling file found. Allowing refresh.");
-        return false;
-    } catch (err) {
-        console.error('Error during directory traversal:', err);
-        return false;
-    }
+		// If no sibling file was found and we reached the root, return false to allow refresh
+		console.log("Reached project root, no sibling file found. Allowing refresh.");
+		return false;
+	} catch (err) {
+		console.error('Error during directory traversal:', err);
+		return false;
+	}
 }
 


### PR DESCRIPTION
Fixes #455 
changes includes allowing the dashboard refresh by checking  if a build file that is  generated in the build directory,  then we traverse up the path of the file generated to see if there is a build directory and build file sibling existing. if yes , then we ignore the file that is generated and block the dashboard refresh, if no such sibling is found we allow the dashboard refresh.