### PR TITLE
Add LSP hover tests

### DIFF
--- a/src/test/GradleTestDevModeActions.ts
+++ b/src/test/GradleTestDevModeActions.ts
@@ -3,12 +3,10 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import { expect } from 'chai';
-import { InputBox, Workbench, SideBarView, ViewSection, EditorView, DefaultTreeItem, DebugView } from 'vscode-extension-tester';
+import { DebugView, DefaultTreeItem, EditorView, InputBox, SideBarView, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
-import * as fs from 'fs';
-import { VSBrowser } from 'vscode-extension-tester';
 import path = require('path');
 
 describe('Devmode action tests for Gradle Project', () => {
@@ -38,6 +36,14 @@ describe('Devmode action tests for Gradle Project', () => {
             await new EditorView().closeAllEditors();
         } catch (error) {
             logger.error('Failed to close editors in afterEach', error);
+        }
+        
+        // Clear terminal between tests to avoid confusion with old output
+        try {
+            const workbench = new Workbench();
+            await workbench.executeCommand('terminal clear');
+        } catch (error) {
+            logger.error('Failed to clear terminal in afterEach', error);
         }
     });
 
@@ -387,10 +393,10 @@ describe('Devmode action tests for Gradle Project', () => {
                 logger.info('Attach Debugger action completed');
 
                 logger.step(6, 'Waiting for debugger to attach');
-                attachStatus = await utils.waitForDebuggerAttach(debugView);
+                attachStatus = await utils.waitForDebuggerAttach();
 
                 if (!attachStatus) {
-                    logger.error('BREAKPOINTS section not found - debugger may not have attached');
+                    logger.error('DebugToolbar not found - debugger may not have attached');
                 } else {
                     logger.stepSuccess(6, 'Debugger attached successfully');
                 }

--- a/src/test/GradleTestDevModeActions.ts
+++ b/src/test/GradleTestDevModeActions.ts
@@ -25,6 +25,7 @@ describe('Devmode action tests for Gradle Project', () => {
     });
 
     afterEach(async function() {
+        this.timeout(10000); // Increase timeout for cleanup operations
         // Close any open editors after each test
         if (this.currentTest?.state === 'failed') {
             const driver = VSBrowser.instance.driver;

--- a/src/test/GradleTestDevModeActions.ts
+++ b/src/test/GradleTestDevModeActions.ts
@@ -3,7 +3,7 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import { expect } from 'chai';
-import { DebugView, DefaultTreeItem, EditorView, InputBox, SideBarView, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
+import { DefaultTreeItem, EditorView, InputBox, SideBarView, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
@@ -11,7 +11,6 @@ import path = require('path');
 
 describe('Devmode action tests for Gradle Project', () => {
     let sidebar: SideBarView;
-    let debugView: DebugView;
     let section: ViewSection;
     let item: DefaultTreeItem;
     let tabs: string[];
@@ -21,7 +20,6 @@ describe('Devmode action tests for Gradle Project', () => {
         // Wait for workbench to be ready
         await VSBrowser.instance.waitForWorkbench();
         sidebar = new SideBarView();
-        debugView = new DebugView();
     });
 
     afterEach(async function() {

--- a/src/test/GradleTestLSPHover.ts
+++ b/src/test/GradleTestLSPHover.ts
@@ -83,12 +83,12 @@ describe('LSP Hover tests for Gradle Project', () => {
 
     // Test data for parameterized hover tests
     const hoverTestCases = [
-        { element: 'httpEndpoint element', line: 18, column: 10 },
-        { element: 'feature element', line: 15, column: 16 },
-        { element: 'featureManager element', line: 14, column: 10 },
-        { element: 'webApplication element', line: 20, column: 10 },
-        { element: 'jsp-2.3 feature value', line: 15, column: 22 },
-        { element: 'httpPort attribute', line: 18, column: 33 }
+        { element: 'httpEndpoint element', line: 18, column: 10, expectedDoc: 'Configuration properties for an HTTP endpoint.' },
+        { element: 'feature element', line: 15, column: 16, expectedDoc: 'Specifies a feature to be used when the server runs.' },
+        { element: 'featureManager element', line: 14, column: 10, expectedDoc: 'Defines how the server loads features.' },
+        { element: 'webApplication element', line: 20, column: 10, expectedDoc: 'Defines the properties of a web application.' },
+        { element: 'jsp-2.3 feature value', line: 15, column: 22, expectedDoc: 'This feature enables support for Java Server Pages (JSPs) that are written to the JSP 2.3 specification.' },
+        { element: 'httpPort attribute', line: 18, column: 33, expectedDoc: 'The port used for client HTTP requests. Use -1 to disable this port.' }
     ];
 
     hoverTestCases.forEach(testCase => {
@@ -107,10 +107,14 @@ describe('LSP Hover tests for Gradle Project', () => {
 
                 logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
                 const driver = VSBrowser.instance.driver;
-                const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
+                const hoverText = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                 
-                expect(hoverVisible).to.be.true;
+                expect(hoverText).to.not.be.empty;
                 logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
+
+                logger.step(4, 'Verifying hover contains expected documentation');
+                expect(hoverText).to.include(testCase.expectedDoc);
+                logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
 
                 logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
             } catch (error) {
@@ -168,10 +172,10 @@ describe('LSP Hover tests for Gradle Project', () => {
 
         // Test data for LSP4Jakarta hover tests
         const jakartaHoverTestCases = [
-            { element: '@WebServlet annotation', line: 23, column: 2 },
-            { element: 'HttpServlet class', line: 24, column: 35 },
-            { element: 'HttpServletRequest type', line: 30, column: 35 },
-            { element: 'HttpServletResponse type', line: 30, column: 70 }
+            { element: '@WebServlet annotation', line: 23, column: 2, expectedDoc: 'Annotation used to declare a servlet.' },
+            { element: 'HttpServlet class', line: 24, column: 35, expectedDoc: 'Provides an abstract class to be subclassed to create an HTTP servlet suitable for a Web site.' },
+            { element: 'HttpServletRequest type', line: 30, column: 35, expectedDoc: 'Extends the javax.servlet.ServletRequest interface to provide request information for HTTP servlets.' },
+            { element: 'HttpServletResponse type', line: 30, column: 70, expectedDoc: 'Extends the ServletResponse interface to provide HTTP-specific functionality in sending a response.' }
         ];
 
         jakartaHoverTestCases.forEach(testCase => {
@@ -190,10 +194,14 @@ describe('LSP Hover tests for Gradle Project', () => {
 
                     logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
                     const driver = VSBrowser.instance.driver;
-                    const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
+                    const hoverText = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                     
-                    expect(hoverVisible).to.be.true;
+                    expect(hoverText).to.not.be.empty;
                     logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);
+
+                    logger.step(4, 'Verifying hover contains expected documentation');
+                    expect(hoverText).to.include(testCase.expectedDoc);
+                    logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
 
                     logger.testComplete(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
                 } catch (error) {

--- a/src/test/GradleTestLSPHover.ts
+++ b/src/test/GradleTestLSPHover.ts
@@ -1,0 +1,243 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+import { expect } from 'chai';
+import { EditorView, TextEditor, VSBrowser, Workbench, StatusBar } from 'vscode-extension-tester';
+import * as utils from './utils/testUtils';
+import * as constants from './definitions/constants';
+import { logger } from './utils/testLogger';
+import * as path from 'path';
+
+describe('LSP Hover tests for Gradle Project', () => {
+    let editorView: EditorView;
+    let editor: TextEditor;
+    let wait: any;
+
+    before(async function() {
+        this.timeout(60000);
+        logger.info('Setting up Gradle LSP Hover tests');
+        
+        // Wait for workbench to be ready
+        await VSBrowser.instance.waitForWorkbench();
+        editorView = new EditorView();
+        wait = utils.getWaitHelper();
+
+        // Open server.xml file once for all tests
+        logger.info('Opening server.xml file for all tests');
+        const serverXmlPath = path.resolve(
+            utils.getGradleProjectPath(),
+            'src',
+            'main',
+            'liberty',
+            'config',
+            'server.xml'
+        );
+        logger.info(`Server.xml path: ${serverXmlPath}`);
+
+        await VSBrowser.instance.openResources(serverXmlPath, async () => {
+            await wait.sleep(3000); // Allow time for file to load
+        });
+        
+        editor = await editorView.openEditor('server.xml') as TextEditor;
+        logger.info('Server.xml file opened and editor obtained');
+
+        // Wait for language server to initialize
+        await wait.forCondition(async () => {
+            try {
+                const statusBar = new StatusBar();
+                const languageItem = await statusBar.getItem('Initializing JS/TS language features');
+                return !languageItem;
+            } catch {
+                return true;
+            }
+        }, {
+            timeout: 30000,
+            pollInterval: 2000,
+            message: 'Language server did not initialize'
+        });
+        logger.info('Language server initialized');
+    });
+
+    afterEach(async function() {
+        // Take screenshot on failure but don't close editor
+        if (this.currentTest?.state === 'failed') {
+            const driver = VSBrowser.instance.driver;
+            const screenshot = await driver.takeScreenshot();
+            logger.error(`Test failed: ${this.currentTest.title}`);
+        }
+    });
+
+    after(async function() {
+        // Close editor after all tests complete
+        try {
+            await editorView.closeAllEditors();
+            logger.info('Closed all editors after test suite');
+        } catch (error) {
+            logger.error('Failed to close editors in after hook', error);
+        }
+        
+        utils.copyScreenshotsToProjectFolder('gradle-lsp-hover');
+    });
+
+    // Test data for parameterized hover tests
+    const hoverTestCases = [
+        { element: 'httpEndpoint element', line: 18, column: 10 },
+        { element: 'feature element', line: 15, column: 16 },
+        { element: 'featureManager element', line: 14, column: 10 },
+        { element: 'webApplication element', line: 20, column: 10 },
+        { element: 'jsp-2.3 feature value', line: 15, column: 22 },
+        { element: 'httpPort attribute', line: 18, column: 33 }
+    ];
+
+    hoverTestCases.forEach(testCase => {
+        it(`Hover over ${testCase.element} shows Liberty Language Server documentation`, async function() {
+            this.timeout(30000);
+            logger.testStart(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+            
+            try {
+                logger.step(1, `Setting cursor position on ${testCase.element}`);
+                await editor.setCursor(testCase.line, testCase.column);
+                logger.stepSuccess(1, `Cursor positioned on ${testCase.element} at line ${testCase.line}`);
+
+                logger.step(2, 'Triggering hover via command palette');
+                await new Workbench().executeCommand('editor.action.showHover');
+                logger.stepSuccess(2, 'Hover command executed');
+
+                logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
+                const driver = VSBrowser.instance.driver;
+                const hoverVisible = await wait.forCondition(async () => {
+                    try {
+                        const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
+                        const isDisplayed = await hoverWidget.isDisplayed();
+                        if (isDisplayed) {
+                            const hoverText = await hoverWidget.getText();
+                            logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
+                            // Verify hover contains content (Liberty LS provides documentation)
+                            return hoverText && hoverText.length > 0;
+                        }
+                    } catch {
+                        return;
+                    }
+                    return;
+                }, {
+                    timeout: 10000,
+                    pollInterval: 500,
+                    message: `Hover widget did not appear with content for ${testCase.element}`
+                });
+                
+                expect(hoverVisible).to.be.true;
+                logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
+
+                logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+            } catch (error) {
+                logger.testFailed(`Hover over ${testCase.element} shows Liberty Language Server documentation`, error);
+                throw error;
+            }
+        });
+    });
+
+    describe('LSP4Jakarta Hover tests in Java file', () => {
+        let javaEditor: TextEditor;
+
+        before(async function() {
+            this.timeout(60000);
+            logger.info('Opening HelloServlet.java file for LSP4Jakarta hover tests');
+            
+            const javaFilePath = path.resolve(
+                utils.getGradleProjectPath(),
+                'src',
+                'main',
+                'java',
+                'test',
+                'gradle',
+                'liberty',
+                'web',
+                'app',
+                'HelloServlet.java'
+            );
+            logger.info(`Java file path: ${javaFilePath}`);
+
+            await VSBrowser.instance.openResources(javaFilePath, async () => {
+                await wait.sleep(3000); // Allow time for file to load
+            });
+            
+            javaEditor = await editorView.openEditor('HelloServlet.java') as TextEditor;
+            logger.info('HelloServlet.java file opened and editor obtained');
+
+            // Wait for Java language server to initialize
+            await wait.forCondition(async () => {
+                try {
+                    const statusBar = new StatusBar();
+                    const languageItem = await statusBar.getItem('Initializing JS/TS language features');
+                    return !languageItem;
+                } catch {
+                    return true;
+                }
+            }, {
+                timeout: 30000,
+                pollInterval: 2000,
+                message: 'Java language server did not initialize'
+            });
+            logger.info('Java language server initialized');
+        });
+
+        // Test data for LSP4Jakarta hover tests
+        const jakartaHoverTestCases = [
+            { element: '@WebServlet annotation', line: 23, column: 2 },
+            { element: 'HttpServlet class', line: 24, column: 35 },
+            { element: 'HttpServletRequest type', line: 30, column: 35 },
+            { element: 'HttpServletResponse type', line: 30, column: 70 }
+        ];
+
+        jakartaHoverTestCases.forEach(testCase => {
+            it(`Hover over ${testCase.element} shows LSP4Jakarta documentation`, async function() {
+                this.timeout(30000);
+                logger.testStart(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
+                
+                try {
+                    logger.step(1, `Setting cursor position on ${testCase.element}`);
+                    await javaEditor.setCursor(testCase.line, testCase.column);
+                    logger.stepSuccess(1, `Cursor positioned on ${testCase.element} at line ${testCase.line}`);
+
+                    logger.step(2, 'Triggering hover via command palette');
+                    await new Workbench().executeCommand('editor.action.showHover');
+                    logger.stepSuccess(2, 'Hover command executed');
+
+                    logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
+                    const driver = VSBrowser.instance.driver;
+                    const hoverVisible = await wait.forCondition(async () => {
+                        try {
+                            const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
+                            const isDisplayed = await hoverWidget.isDisplayed();
+                            if (isDisplayed) {
+                                const hoverText = await hoverWidget.getText();
+                                logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
+                                // Verify hover contains content (LSP4Jakarta provides documentation)
+                                return hoverText && hoverText.length > 0;
+                            }
+                        } catch {
+                            return;
+                        }
+                        return;
+                    }, {
+                        timeout: 10000,
+                        pollInterval: 500,
+                        message: `Hover widget did not appear with content for ${testCase.element}`
+                    });
+                    
+                    expect(hoverVisible).to.be.true;
+                    logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);
+
+                    logger.testComplete(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
+                } catch (error) {
+                    logger.testFailed(`Hover over ${testCase.element} shows LSP4Jakarta documentation`, error);
+                    throw error;
+                }
+            });
+        });
+    });
+
+});
+
+// Made with Bob

--- a/src/test/GradleTestLSPHover.ts
+++ b/src/test/GradleTestLSPHover.ts
@@ -3,9 +3,8 @@
  * Copyright IBM Corp. 2026
  */
 import { expect } from 'chai';
-import { EditorView, TextEditor, VSBrowser, Workbench, StatusBar } from 'vscode-extension-tester';
+import { EditorView, TextEditor, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
-import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
 import * as path from 'path';
 
@@ -41,22 +40,6 @@ describe('LSP Hover tests for Gradle Project', () => {
         
         editor = await editorView.openEditor('server.xml') as TextEditor;
         logger.info('Server.xml file opened and editor obtained');
-
-        // Wait for language server to initialize
-        await wait.forCondition(async () => {
-            try {
-                const statusBar = new StatusBar();
-                const languageItem = await statusBar.getItem('Initializing JS/TS language features');
-                return !languageItem;
-            } catch {
-                return true;
-            }
-        }, {
-            timeout: 30000,
-            pollInterval: 2000,
-            message: 'Language server did not initialize'
-        });
-        logger.info('Language server initialized');
     });
 
     afterEach(async function() {
@@ -77,7 +60,24 @@ describe('LSP Hover tests for Gradle Project', () => {
             logger.error('Failed to close editors in after hook', error);
         }
         
-        utils.copyScreenshotsToProjectFolder('gradle-lsp-hover');
+        utils.copyScreenshotsToProjectFolder('gradle');
+    });
+
+    it('Liberty Language Server should initialize', async function() {
+        this.timeout(60000);
+        logger.testStart('Liberty Language Server should initialize');
+        
+        try {
+            await utils.waitForLanguageServerInit(
+                'Language Support for Liberty',
+                'Initialized Liberty Language server',
+                60
+            );
+            logger.testComplete('Liberty Language Server initialized successfully');
+        } catch (error) {
+            logger.testFailed('Liberty Language Server should initialize', error);
+            throw error;
+        }
     });
 
     // Test data for parameterized hover tests
@@ -164,22 +164,23 @@ describe('LSP Hover tests for Gradle Project', () => {
             
             javaEditor = await editorView.openEditor('HelloServlet.java') as TextEditor;
             logger.info('HelloServlet.java file opened and editor obtained');
+        });
 
-            // Wait for Java language server to initialize
-            await wait.forCondition(async () => {
-                try {
-                    const statusBar = new StatusBar();
-                    const languageItem = await statusBar.getItem('Initializing JS/TS language features');
-                    return !languageItem;
-                } catch {
-                    return true;
-                }
-            }, {
-                timeout: 30000,
-                pollInterval: 2000,
-                message: 'Java language server did not initialize'
-            });
-            logger.info('Java language server initialized');
+        it('LSP4Jakarta Language Server should initialize', async function() {
+            this.timeout(60000);
+            logger.testStart('LSP4Jakarta Language Server should initialize');
+            
+            try {
+                await utils.waitForLanguageServerInit(
+                    'Language Support for Jakarta EE',
+                    'Initializing Jakarta EE server',
+                    60
+                );
+                logger.testComplete('LSP4Jakarta Language Server initialized successfully');
+            } catch (error) {
+                logger.testFailed('LSP4Jakarta Language Server should initialize', error);
+                throw error;
+            }
         });
 
         // Test data for LSP4Jakarta hover tests

--- a/src/test/GradleTestLSPHover.ts
+++ b/src/test/GradleTestLSPHover.ts
@@ -52,6 +52,7 @@ describe('LSP Hover tests for Gradle Project', () => {
     });
 
     after(async function() {
+        this.timeout(10000); // Increase timeout for cleanup operations
         // Close editor after all tests complete
         try {
             await editorView.closeAllEditors();
@@ -106,25 +107,7 @@ describe('LSP Hover tests for Gradle Project', () => {
 
                 logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
                 const driver = VSBrowser.instance.driver;
-                const hoverVisible = await wait.forCondition(async () => {
-                    try {
-                        const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
-                        const isDisplayed = await hoverWidget.isDisplayed();
-                        if (isDisplayed) {
-                            const hoverText = await hoverWidget.getText();
-                            logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
-                            // Verify hover contains content (Liberty LS provides documentation)
-                            return hoverText && hoverText.length > 0;
-                        }
-                    } catch {
-                        return;
-                    }
-                    return;
-                }, {
-                    timeout: 10000,
-                    pollInterval: 500,
-                    message: `Hover widget did not appear with content for ${testCase.element}`
-                });
+                const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                 
                 expect(hoverVisible).to.be.true;
                 logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
@@ -207,25 +190,7 @@ describe('LSP Hover tests for Gradle Project', () => {
 
                     logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
                     const driver = VSBrowser.instance.driver;
-                    const hoverVisible = await wait.forCondition(async () => {
-                        try {
-                            const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
-                            const isDisplayed = await hoverWidget.isDisplayed();
-                            if (isDisplayed) {
-                                const hoverText = await hoverWidget.getText();
-                                logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
-                                // Verify hover contains content (LSP4Jakarta provides documentation)
-                                return hoverText && hoverText.length > 0;
-                            }
-                        } catch {
-                            return;
-                        }
-                        return;
-                    }, {
-                        timeout: 10000,
-                        pollInterval: 500,
-                        message: `Hover widget did not appear with content for ${testCase.element}`
-                    });
+                    const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                     
                     expect(hoverVisible).to.be.true;
                     logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -26,6 +26,7 @@ describe('Devmode action tests for Maven Project', () => {
     });
 
     afterEach(async function() {
+        this.timeout(10000); // Increase timeout for cleanup operations
         // Close any open editors after each test
         if (this.currentTest?.state === 'failed') {
             const driver = VSBrowser.instance.driver;

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -3,12 +3,11 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import { expect } from 'chai';
-import { SideBarView, ViewItem, ViewSection, EditorView, DefaultTreeItem, DebugView, VSBrowser } from 'vscode-extension-tester';
+import { DebugView, DefaultTreeItem, EditorView, SideBarView, ViewItem, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
 import path = require('path');
-import * as fs from 'fs';
 
 describe('Devmode action tests for Maven Project', () => {
     let sidebar: SideBarView;
@@ -38,6 +37,14 @@ describe('Devmode action tests for Maven Project', () => {
             await new EditorView().closeAllEditors();
         } catch (error) {
             logger.error('Failed to close editors in afterEach', error);
+        }
+        
+        // Clear terminal between tests to avoid confusion with old output
+        try {
+            const workbench = new Workbench();
+            await workbench.executeCommand('terminal clear');
+        } catch (error) {
+            logger.error('Failed to clear terminal in afterEach', error);
         }
     });
 
@@ -265,33 +272,22 @@ describe('Devmode action tests for Maven Project', () => {
             } else {
                 logger.stepSuccess(5, 'Server successfully started with custom parameters');
 
-                logger.step(6, 'Waiting for test report at primary location');
-                let checkFile = await utils.waitForTestReport(reportPath);
-                logger.info(`Primary report exists: ${checkFile}`);
-
-                if (!checkFile) {
-                    logger.step(7, 'Checking alternate report location');
-                    checkFile = await utils.waitForTestReport(alternateReportPath);
-                    if (checkFile) {
-                        logger.info('Test report found at alternate location');
-                    } else {
-                        logger.error('Test report not found at either location');
-                    }
-                }
+                logger.step(6, 'Waiting for test report at primary or alternate location');
+                const checkFile = await utils.waitForTestReport(reportPath, alternateReportPath);
 
                 expect(checkFile).to.be.true;
-                logger.stepSuccess(7, 'Test report found');
+                logger.stepSuccess(6, 'Test report found');
 
-                logger.step(8, 'Launching dashboard stop action');
+                logger.step(7, 'Launching dashboard stop action');
                 await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);
 
-                logger.step(9, 'Waiting for server to stop');
+                logger.step(8, 'Waiting for server to stop');
                 const serverStopStatus = await utils.waitForServerStop(constants.SERVER_STOP_STRING);
 
                 if (!serverStopStatus) {
                     logger.error('Server stopped message not found in the terminal');
                 } else {
-                    logger.stepSuccess(9, 'Server stopped successfully');
+                    logger.stepSuccess(8, 'Server stopped successfully');
                 }
                 expect(serverStopStatus).to.be.true;
             }
@@ -340,33 +336,22 @@ describe('Devmode action tests for Maven Project', () => {
             } else {
                 logger.stepSuccess(5, 'Server successfully started with historical parameters');
 
-                logger.step(6, 'Waiting for test report at primary location');
-                let checkFile = await utils.waitForTestReport(reportPath);
-                logger.info(`Primary report exists: ${checkFile}`);
-
-                if (!checkFile) {
-                    logger.step(7, 'Checking alternate report location');
-                    checkFile = await utils.waitForTestReport(alternateReportPath);
-                    if (checkFile) {
-                        logger.info('Test report found at alternate location');
-                    } else {
-                        logger.error('Test report not found at either location');
-                    }
-                }
+                logger.step(6, 'Waiting for test report at primary or alternate location');
+                const checkFile = await utils.waitForTestReport(reportPath, alternateReportPath);
 
                 expect(checkFile).to.be.true;
-                logger.stepSuccess(7, 'Test report found');
+                logger.stepSuccess(6, 'Test report found');
 
-                logger.step(8, 'Launching dashboard stop action');
+                logger.step(7, 'Launching dashboard stop action');
                 await utils.launchDashboardAction(item, constants.STOP_DASHBOARD_ACTION, constants.STOP_DASHBOARD_MAC_ACTION);
 
-                logger.step(9, 'Waiting for server to stop');
+                logger.step(8, 'Waiting for server to stop');
                 const serverStopStatus = await utils.waitForServerStop(constants.SERVER_STOP_STRING);
 
                 if (!serverStopStatus) {
                     logger.error('Server stopped message not found in terminal');
                 } else {
-                    logger.stepSuccess(9, 'Server stopped successfully');
+                    logger.stepSuccess(8, 'Server stopped successfully');
                 }
                 expect(serverStopStatus).to.be.true;
             }
@@ -475,10 +460,10 @@ describe('Devmode action tests for Maven Project', () => {
                 logger.info('Attach Debugger action completed');
 
                 logger.step(6, 'Waiting for debugger to attach');
-                attachStatus = await utils.waitForDebuggerAttach(debugView);
+                attachStatus = await utils.waitForDebuggerAttach();
 
                 if (!attachStatus) {
-                    logger.error('BREAKPOINTS section not found - debugger may not have attached');
+                    logger.error('DebugToolbar not found - debugger may not have attached');
                 } else {
                     logger.stepSuccess(6, 'Debugger attached successfully');
                 }

--- a/src/test/MavenTestDevModeActions.ts
+++ b/src/test/MavenTestDevModeActions.ts
@@ -3,7 +3,7 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import { expect } from 'chai';
-import { DebugView, DefaultTreeItem, EditorView, SideBarView, ViewItem, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
+import { DefaultTreeItem, EditorView, SideBarView, ViewItem, ViewSection, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
@@ -11,7 +11,6 @@ import path = require('path');
 
 describe('Devmode action tests for Maven Project', () => {
     let sidebar: SideBarView;
-    let debugView: DebugView;
     let section: ViewSection;
     let menu: ViewItem[];
     let item: DefaultTreeItem;
@@ -22,7 +21,6 @@ describe('Devmode action tests for Maven Project', () => {
         // Wait for workbench to be ready
         await VSBrowser.instance.waitForWorkbench();
         sidebar = new SideBarView();
-        debugView = new DebugView();
     });
 
     afterEach(async function() {

--- a/src/test/MavenTestLSPHover.ts
+++ b/src/test/MavenTestLSPHover.ts
@@ -1,0 +1,243 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+import { expect } from 'chai';
+import { EditorView, TextEditor, VSBrowser, Workbench, StatusBar } from 'vscode-extension-tester';
+import * as utils from './utils/testUtils';
+import * as constants from './definitions/constants';
+import { logger } from './utils/testLogger';
+import * as path from 'path';
+
+describe('LSP Hover tests for Maven Project', () => {
+    let editorView: EditorView;
+    let editor: TextEditor;
+    let wait: any;
+
+    before(async function() {
+        this.timeout(60000);
+        logger.info('Setting up Maven LSP Hover tests');
+        
+        // Wait for workbench to be ready
+        await VSBrowser.instance.waitForWorkbench();
+        editorView = new EditorView();
+        wait = utils.getWaitHelper();
+
+        // Open server.xml file once for all tests
+        logger.info('Opening server.xml file for all tests');
+        const serverXmlPath = path.resolve(
+            utils.getMvnProjectPath(),
+            'src',
+            'main',
+            'liberty',
+            'config',
+            'server.xml'
+        );
+        logger.info(`Server.xml path: ${serverXmlPath}`);
+
+        await VSBrowser.instance.openResources(serverXmlPath, async () => {
+            await wait.sleep(3000); // Allow time for file to load
+        });
+        
+        editor = await editorView.openEditor('server.xml') as TextEditor;
+        logger.info('Server.xml file opened and editor obtained');
+
+        // Wait for language server to initialize
+        await wait.forCondition(async () => {
+            try {
+                const statusBar = new StatusBar();
+                const languageItem = await statusBar.getItem('Initializing JS/TS language features');
+                return !languageItem;
+            } catch {
+                return true;
+            }
+        }, {
+            timeout: 30000,
+            pollInterval: 2000,
+            message: 'Language server did not initialize'
+        });
+        logger.info('Language server initialized');
+    });
+
+    afterEach(async function() {
+        // Take screenshot on failure but don't close editor
+        if (this.currentTest?.state === 'failed') {
+            const driver = VSBrowser.instance.driver;
+            const screenshot = await driver.takeScreenshot();
+            logger.error(`Test failed: ${this.currentTest.title}`);
+        }
+    });
+
+    after(async function() {
+        // Close editor after all tests complete
+        try {
+            await editorView.closeAllEditors();
+            logger.info('Closed all editors after test suite');
+        } catch (error) {
+            logger.error('Failed to close editors in after hook', error);
+        }
+        
+        utils.copyScreenshotsToProjectFolder('maven-lsp-hover');
+    });
+
+    // Test data for parameterized hover tests
+    const hoverTestCases = [
+        { element: 'httpEndpoint element', line: 19, column: 10 },
+        { element: 'feature element', line: 16, column: 16 },
+        { element: 'featureManager element', line: 15, column: 10 },
+        { element: 'webApplication element', line: 21, column: 10 },
+        { element: 'jsp-2.3 feature value', line: 16, column: 22 },
+        { element: 'httpPort attribute', line: 19, column: 33 }
+    ];
+
+    hoverTestCases.forEach(testCase => {
+        it(`Hover over ${testCase.element} shows Liberty Language Server documentation`, async function() {
+            this.timeout(30000);
+            logger.testStart(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+            
+            try {
+                logger.step(1, `Setting cursor position on ${testCase.element}`);
+                await editor.setCursor(testCase.line, testCase.column);
+                logger.stepSuccess(1, `Cursor positioned on ${testCase.element} at line ${testCase.line}`);
+
+                logger.step(2, 'Triggering hover via command palette');
+                await new Workbench().executeCommand('editor.action.showHover');
+                logger.stepSuccess(2, 'Hover command executed');
+
+                logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
+                const driver = VSBrowser.instance.driver;
+                const hoverVisible = await wait.forCondition(async () => {
+                    try {
+                        const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
+                        const isDisplayed = await hoverWidget.isDisplayed();
+                        if (isDisplayed) {
+                            const hoverText = await hoverWidget.getText();
+                            logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
+                            // Verify hover contains content (Liberty LS provides documentation)
+                            return hoverText && hoverText.length > 0;
+                        }
+                    } catch {
+                        return;
+                    }
+                    return;
+                }, {
+                    timeout: 10000,
+                    pollInterval: 500,
+                    message: `Hover widget did not appear with content for ${testCase.element}`
+                });
+                
+                expect(hoverVisible).to.be.true;
+                logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
+
+                logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+            } catch (error) {
+                logger.testFailed(`Hover over ${testCase.element} shows Liberty Language Server documentation`, error);
+                throw error;
+            }
+        });
+    });
+
+    describe('LSP4Jakarta Hover tests in Java file', () => {
+        let javaEditor: TextEditor;
+
+        before(async function() {
+            this.timeout(60000);
+            logger.info('Opening HelloServlet.java file for LSP4Jakarta hover tests');
+            
+            const javaFilePath = path.resolve(
+                utils.getMvnProjectPath(),
+                'src',
+                'main',
+                'java',
+                'test',
+                'maven',
+                'liberty',
+                'web',
+                'app',
+                'HelloServlet.java'
+            );
+            logger.info(`Java file path: ${javaFilePath}`);
+
+            await VSBrowser.instance.openResources(javaFilePath, async () => {
+                await wait.sleep(3000); // Allow time for file to load
+            });
+            
+            javaEditor = await editorView.openEditor('HelloServlet.java') as TextEditor;
+            logger.info('HelloServlet.java file opened and editor obtained');
+
+            // Wait for Java language server to initialize
+            await wait.forCondition(async () => {
+                try {
+                    const statusBar = new StatusBar();
+                    const languageItem = await statusBar.getItem('Initializing JS/TS language features');
+                    return !languageItem;
+                } catch {
+                    return true;
+                }
+            }, {
+                timeout: 30000,
+                pollInterval: 2000,
+                message: 'Java language server did not initialize'
+            });
+            logger.info('Java language server initialized');
+        });
+
+        // Test data for LSP4Jakarta hover tests
+        const jakartaHoverTestCases = [
+            { element: '@WebServlet annotation', line: 23, column: 2 },
+            { element: 'HttpServlet class', line: 24, column: 35 },
+            { element: 'HttpServletRequest type', line: 30, column: 35 },
+            { element: 'HttpServletResponse type', line: 30, column: 70 }
+        ];
+
+        jakartaHoverTestCases.forEach(testCase => {
+            it(`Hover over ${testCase.element} shows LSP4Jakarta documentation`, async function() {
+                this.timeout(30000);
+                logger.testStart(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
+                
+                try {
+                    logger.step(1, `Setting cursor position on ${testCase.element}`);
+                    await javaEditor.setCursor(testCase.line, testCase.column);
+                    logger.stepSuccess(1, `Cursor positioned on ${testCase.element} at line ${testCase.line}`);
+
+                    logger.step(2, 'Triggering hover via command palette');
+                    await new Workbench().executeCommand('editor.action.showHover');
+                    logger.stepSuccess(2, 'Hover command executed');
+
+                    logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
+                    const driver = VSBrowser.instance.driver;
+                    const hoverVisible = await wait.forCondition(async () => {
+                        try {
+                            const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
+                            const isDisplayed = await hoverWidget.isDisplayed();
+                            if (isDisplayed) {
+                                const hoverText = await hoverWidget.getText();
+                                logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
+                                // Verify hover contains content (LSP4Jakarta provides documentation)
+                                return hoverText && hoverText.length > 0;
+                            }
+                        } catch {
+                            return;
+                        }
+                        return;
+                    }, {
+                        timeout: 10000,
+                        pollInterval: 500,
+                        message: `Hover widget did not appear with content for ${testCase.element}`
+                    });
+                    
+                    expect(hoverVisible).to.be.true;
+                    logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);
+
+                    logger.testComplete(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
+                } catch (error) {
+                    logger.testFailed(`Hover over ${testCase.element} shows LSP4Jakarta documentation`, error);
+                    throw error;
+                }
+            });
+        });
+    });
+
+});
+
+// Made with Bob

--- a/src/test/MavenTestLSPHover.ts
+++ b/src/test/MavenTestLSPHover.ts
@@ -52,6 +52,7 @@ describe('LSP Hover tests for Maven Project', () => {
     });
 
     after(async function() {
+        this.timeout(10000); // Increase timeout for cleanup operations
         // Close editor after all tests complete
         try {
             await editorView.closeAllEditors();
@@ -106,25 +107,7 @@ describe('LSP Hover tests for Maven Project', () => {
 
                 logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
                 const driver = VSBrowser.instance.driver;
-                const hoverVisible = await wait.forCondition(async () => {
-                    try {
-                        const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
-                        const isDisplayed = await hoverWidget.isDisplayed();
-                        if (isDisplayed) {
-                            const hoverText = await hoverWidget.getText();
-                            logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
-                            // Verify hover contains content (Liberty LS provides documentation)
-                            return hoverText && hoverText.length > 0;
-                        }
-                    } catch {
-                        return;
-                    }
-                    return;
-                }, {
-                    timeout: 10000,
-                    pollInterval: 500,
-                    message: `Hover widget did not appear with content for ${testCase.element}`
-                });
+                const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                 
                 expect(hoverVisible).to.be.true;
                 logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
@@ -207,25 +190,7 @@ describe('LSP Hover tests for Maven Project', () => {
 
                     logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
                     const driver = VSBrowser.instance.driver;
-                    const hoverVisible = await wait.forCondition(async () => {
-                        try {
-                            const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
-                            const isDisplayed = await hoverWidget.isDisplayed();
-                            if (isDisplayed) {
-                                const hoverText = await hoverWidget.getText();
-                                logger.info(`Hover content for ${testCase.element}: ${hoverText.length} characters`);
-                                // Verify hover contains content (LSP4Jakarta provides documentation)
-                                return hoverText && hoverText.length > 0;
-                            }
-                        } catch {
-                            return;
-                        }
-                        return;
-                    }, {
-                        timeout: 10000,
-                        pollInterval: 500,
-                        message: `Hover widget did not appear with content for ${testCase.element}`
-                    });
+                    const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                     
                     expect(hoverVisible).to.be.true;
                     logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);

--- a/src/test/MavenTestLSPHover.ts
+++ b/src/test/MavenTestLSPHover.ts
@@ -3,9 +3,8 @@
  * Copyright IBM Corp. 2026
  */
 import { expect } from 'chai';
-import { EditorView, TextEditor, VSBrowser, Workbench, StatusBar } from 'vscode-extension-tester';
+import { EditorView, TextEditor, VSBrowser, Workbench } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
-import * as constants from './definitions/constants';
 import { logger } from './utils/testLogger';
 import * as path from 'path';
 
@@ -41,22 +40,6 @@ describe('LSP Hover tests for Maven Project', () => {
         
         editor = await editorView.openEditor('server.xml') as TextEditor;
         logger.info('Server.xml file opened and editor obtained');
-
-        // Wait for language server to initialize
-        await wait.forCondition(async () => {
-            try {
-                const statusBar = new StatusBar();
-                const languageItem = await statusBar.getItem('Initializing JS/TS language features');
-                return !languageItem;
-            } catch {
-                return true;
-            }
-        }, {
-            timeout: 30000,
-            pollInterval: 2000,
-            message: 'Language server did not initialize'
-        });
-        logger.info('Language server initialized');
     });
 
     afterEach(async function() {
@@ -77,7 +60,24 @@ describe('LSP Hover tests for Maven Project', () => {
             logger.error('Failed to close editors in after hook', error);
         }
         
-        utils.copyScreenshotsToProjectFolder('maven-lsp-hover');
+        utils.copyScreenshotsToProjectFolder('maven');
+    });
+
+    it('Liberty Language Server should initialize', async function() {
+        this.timeout(60000);
+        logger.testStart('Liberty Language Server should initialize');
+        
+        try {
+            await utils.waitForLanguageServerInit(
+                'Language Support for Liberty',
+                'Initialized Liberty Language server',
+                60
+            );
+            logger.testComplete('Liberty Language Server initialized successfully');
+        } catch (error) {
+            logger.testFailed('Liberty Language Server should initialize', error);
+            throw error;
+        }
     });
 
     // Test data for parameterized hover tests
@@ -164,22 +164,23 @@ describe('LSP Hover tests for Maven Project', () => {
             
             javaEditor = await editorView.openEditor('HelloServlet.java') as TextEditor;
             logger.info('HelloServlet.java file opened and editor obtained');
+        });
 
-            // Wait for Java language server to initialize
-            await wait.forCondition(async () => {
-                try {
-                    const statusBar = new StatusBar();
-                    const languageItem = await statusBar.getItem('Initializing JS/TS language features');
-                    return !languageItem;
-                } catch {
-                    return true;
-                }
-            }, {
-                timeout: 30000,
-                pollInterval: 2000,
-                message: 'Java language server did not initialize'
-            });
-            logger.info('Java language server initialized');
+        it('LSP4Jakarta Language Server should initialize', async function() {
+            this.timeout(60000);
+            logger.testStart('LSP4Jakarta Language Server should initialize');
+            
+            try {
+                await utils.waitForLanguageServerInit(
+                    'Language Support for Jakarta EE',
+                    'Initializing Jakarta EE server',
+                    60
+                );
+                logger.testComplete('LSP4Jakarta Language Server initialized successfully');
+            } catch (error) {
+                logger.testFailed('LSP4Jakarta Language Server should initialize', error);
+                throw error;
+            }
         });
 
         // Test data for LSP4Jakarta hover tests

--- a/src/test/MavenTestLSPHover.ts
+++ b/src/test/MavenTestLSPHover.ts
@@ -83,12 +83,12 @@ describe('LSP Hover tests for Maven Project', () => {
 
     // Test data for parameterized hover tests
     const hoverTestCases = [
-        { element: 'httpEndpoint element', line: 19, column: 10 },
-        { element: 'feature element', line: 16, column: 16 },
-        { element: 'featureManager element', line: 15, column: 10 },
-        { element: 'webApplication element', line: 21, column: 10 },
-        { element: 'jsp-2.3 feature value', line: 16, column: 22 },
-        { element: 'httpPort attribute', line: 19, column: 33 }
+        { element: 'httpEndpoint element', line: 19, column: 10, expectedDoc: 'Configuration properties for an HTTP endpoint.' },
+        { element: 'feature element', line: 16, column: 16, expectedDoc: 'Specifies a feature to be used when the server runs.' },
+        { element: 'featureManager element', line: 15, column: 10, expectedDoc: 'Defines how the server loads features.' },
+        { element: 'webApplication element', line: 21, column: 10, expectedDoc: 'Defines the properties of a web application.' },
+        { element: 'jsp-2.3 feature value', line: 16, column: 22, expectedDoc: 'This feature enables support for Java Server Pages (JSPs) that are written to the JSP 2.3 specification.' },
+        { element: 'httpPort attribute', line: 19, column: 33, expectedDoc: 'The port used for client HTTP requests. Use -1 to disable this port.' }
     ];
 
     hoverTestCases.forEach(testCase => {
@@ -107,10 +107,14 @@ describe('LSP Hover tests for Maven Project', () => {
 
                 logger.step(3, 'Verifying hover widget appears with Liberty Language Server content');
                 const driver = VSBrowser.instance.driver;
-                const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
+                const hoverText = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                 
-                expect(hoverVisible).to.be.true;
+                expect(hoverText).to.not.be.empty;
                 logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
+
+                logger.step(4, 'Verifying hover contains expected documentation');
+                expect(hoverText).to.include(testCase.expectedDoc);
+                logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
 
                 logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
             } catch (error) {
@@ -168,10 +172,10 @@ describe('LSP Hover tests for Maven Project', () => {
 
         // Test data for LSP4Jakarta hover tests
         const jakartaHoverTestCases = [
-            { element: '@WebServlet annotation', line: 23, column: 2 },
-            { element: 'HttpServlet class', line: 24, column: 35 },
-            { element: 'HttpServletRequest type', line: 30, column: 35 },
-            { element: 'HttpServletResponse type', line: 30, column: 70 }
+            { element: '@WebServlet annotation', line: 23, column: 2, expectedDoc: 'Annotation used to declare a servlet.' },
+            { element: 'HttpServlet class', line: 24, column: 35, expectedDoc: 'Provides an abstract class to be subclassed to create an HTTP servlet suitable for a Web site.' },
+            { element: 'HttpServletRequest type', line: 30, column: 35, expectedDoc: 'Extends the javax.servlet.ServletRequest interface to provide request information for HTTP servlets.' },
+            { element: 'HttpServletResponse type', line: 30, column: 70, expectedDoc: 'Extends the ServletResponse interface to provide HTTP-specific functionality in sending a response.' }
         ];
 
         jakartaHoverTestCases.forEach(testCase => {
@@ -190,10 +194,14 @@ describe('LSP Hover tests for Maven Project', () => {
 
                     logger.step(3, 'Verifying hover widget appears with LSP4Jakarta content');
                     const driver = VSBrowser.instance.driver;
-                    const hoverVisible = await utils.waitForHoverWidget(driver, testCase.element, 15000);
+                    const hoverText = await utils.waitForHoverWidget(driver, testCase.element, 15000);
                     
-                    expect(hoverVisible).to.be.true;
+                    expect(hoverText).to.not.be.empty;
                     logger.stepSuccess(3, `Hover widget displayed with LSP4Jakarta content for ${testCase.element}`);
+
+                    logger.step(4, 'Verifying hover contains expected documentation');
+                    expect(hoverText).to.include(testCase.expectedDoc);
+                    logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
 
                     logger.testComplete(`Hover over ${testCase.element} shows LSP4Jakarta documentation`);
                 } catch (error) {

--- a/src/test/resources/ci/scripts/setup.sh
+++ b/src/test/resources/ci/scripts/setup.sh
@@ -20,17 +20,19 @@ OS=$(uname -s)
 
 # Semeru JDK version control constants.
 # Example:
-# Version (SEMERU_OPEN_JDK_BUILD): 11.0.14.1 
-# OpenJDK (SEMERU_OPEN_JDK_BUILD + SEMERU_OPEN_JDK_BUILD): 11.0.14.1+1
-# OpenJ9  (SEMERU_OPENJ9_VERSION): 0.30.1
-SEMERU_OPEN_JDK_MAJOR=17
-SEMERU_OPEN_JDK_VERSION="${SEMERU_OPEN_JDK_MAJOR}.0.6"
-SEMERU_OPEN_JDK_BUILD=10
-SEMERU_OPENJ9_VERSION=0.36.0
+# Version (SEMERU_OPEN_JDK_VERSION): 21
+# OpenJDK (SEMERU_OPEN_JDK_VERSION + SEMERU_OPEN_JDK_BUILD): 21+35
+# OpenJ9  (SEMERU_OPENJ9_VERSION): 0.42.0-m0
+# Releases page: https://github.com/ibmruntimes/semeru21-binaries/releases/tag/jdk-21%2B35_openj9-0.42.0-m0
+# MacOS binary:  https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21%2B35_openj9-0.42.0-m0/ibm-semeru-open-jdk_x64_mac_21_35_openj9-0.42.0-m0.tar.gz
+SEMERU_OPEN_JDK_MAJOR=21
+SEMERU_OPEN_JDK_VERSION="${SEMERU_OPEN_JDK_MAJOR}"
+SEMERU_OPEN_JDK_BUILD=35
+SEMERU_OPENJ9_VERSION=0.42.0-m0
 
-SEMERU_ARCHIVE_MAC_SHA256=37baae44a266c53a90e494be208564c690ed36b7b590f0d75e257efe9173e6c9
-SEMERU_ARCHIVE_LINUX_SHA256=ce39a4f7c2e08e56083f17f3e44c05e0fbbeba775e670f015a337679c99c54c6
-SEMERU_ARCHIVE_WINDOWS_SHA256=4143a9fe93b8a139be34f5789fe61bf197d772600b716fa4b3b8f09c0ab679da
+SEMERU_ARCHIVE_MAC_SHA256=7e6f90dbdb3b72cb8fd23d1287482c00c4d89292f5bce7823dda246ec7c0550f
+SEMERU_ARCHIVE_LINUX_SHA256=e52dbc5513d83f4823e0a7bb317a6aeda8b87aef4f2b951eae9541d4b301a061
+SEMERU_ARCHIVE_WINDOWS_SHA256=9a70de6aea7e43d262d8709c154e0fb387cce23bf48f3271ad0ae74fe0d572fc
 
 # Maven version control constants.
 MAVEN_VERSION=3.8.6
@@ -89,34 +91,47 @@ installCustomSoftware() {
 	installGradle
 }  
 
-# installJDK installs the set version of the Semeru JDK.
+# installJDK installs or configures JDK 21.
+# First tries to use pre-installed JDK 21 from GitHub Actions runner (via JAVA_HOME_21_X64).
+# Falls back to downloading Semeru JDK 21 if not in GHA environment.
 installJDK() {
-	local javaHome="${SOFTWARE_INSTALL_DIR}/jdk-${SEMERU_OPEN_JDK_VERSION}+${SEMERU_OPEN_JDK_BUILD}"
+	local javaHome=""
+	
+	# Check if running in GitHub Actions with pre-installed JDK 21
+	if [[ -n "${JAVA_HOME_21_X64}" && -d "${JAVA_HOME_21_X64}" ]]; then
+		echo "Using pre-installed JDK 21 from GitHub Actions runner"
+		javaHome="${JAVA_HOME_21_X64}"
+	else
+		echo "Downloading and installing Semeru JDK 21"
+		javaHome="${SOFTWARE_INSTALL_DIR}/jdk-${SEMERU_OPEN_JDK_VERSION}+${SEMERU_OPEN_JDK_BUILD}"
+		
+		# Download, validate, and expand the JDK archive.
+		if [[ $OS == "Linux" ]]; then
+			local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_linux_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.tar.gz"
+			curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.tar.gz "$url"
+			echo "${SEMERU_ARCHIVE_LINUX_SHA256}  /tmp/liberty-dev-tool-semeru-jdk.tar.gz" | sha256sum -c -
+			tar -xzf /tmp/liberty-dev-tool-semeru-jdk.tar.gz -C "$SOFTWARE_INSTALL_DIR"
+		elif [[ $OS == "Darwin" ]]; then
+		   javaHome="$javaHome"/Contents/Home
+		   local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_mac_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.tar.gz"
+		   curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.tar.gz "$url"
+		   echo "${SEMERU_ARCHIVE_MAC_SHA256}  /tmp/liberty-dev-tool-semeru-jdk.tar.gz" | shasum -a 256 -c -
+		   tar -xzf /tmp/liberty-dev-tool-semeru-jdk.tar.gz -C "$SOFTWARE_INSTALL_DIR"
+		else
+			local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_windows_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.zip"
+			curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.zip "$url"
+			local shaAll=$(certutil -hashfile /tmp/liberty-dev-tool-semeru-jdk.zip SHA256)
+			local downloadedZipSha=$(echo $(echo $shaAll | tr '\r' ' ') | cut -d " " -f 5)
+			if [ "$SEMERU_ARCHIVE_WINDOWS_SHA256" != "$downloadedZipSha" ]; then
+				echo "ERROR: expected SHA: $SEMERU_ARCHIVE_WINDOWS_SHA256 is not equal to downloaded file calculated SHA of: $downloadedZipSha"
+				exit -1
+			fi
+			unzip /tmp/liberty-dev-tool-semeru-jdk.zip -d "$SOFTWARE_INSTALL_DIR"
+		fi
+	fi
 
-    # Download, validate, and expand the JDK archive.
-	if [[ $OS == "Linux" ]]; then
-        local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_linux_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.tar.gz"
-        curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.tar.gz "$url"
-        echo "${SEMERU_ARCHIVE_LINUX_SHA256}  /tmp/liberty-dev-tool-semeru-jdk.tar.gz" | sha256sum -c - 
-        tar -xzf /tmp/liberty-dev-tool-semeru-jdk.tar.gz -C "$SOFTWARE_INSTALL_DIR"
-    elif [[ $OS == "Darwin" ]]; then
-       javaHome="$javaHome"/Contents/Home
-       local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_mac_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.tar.gz"
-       curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.tar.gz "$url"
-       echo "${SEMERU_ARCHIVE_MAC_SHA256}  /tmp/liberty-dev-tool-semeru-jdk.tar.gz" | shasum -a 256 -c - 
-       tar -xzf /tmp/liberty-dev-tool-semeru-jdk.tar.gz -C "$SOFTWARE_INSTALL_DIR"
-    else
-        local url="https://github.com/ibmruntimes/semeru${SEMERU_OPEN_JDK_MAJOR}-binaries/releases/download/jdk-${SEMERU_OPEN_JDK_VERSION}%2B${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}/ibm-semeru-open-jdk_x64_windows_${SEMERU_OPEN_JDK_VERSION}_${SEMERU_OPEN_JDK_BUILD}_openj9-${SEMERU_OPENJ9_VERSION}.zip"
-        curl -fsSL -o /tmp/liberty-dev-tool-semeru-jdk.zip "$url"
-        local shaAll=$(certutil -hashfile /tmp/liberty-dev-tool-semeru-jdk.zip SHA256)
-        local downloadedZipSha=$(echo $(echo $shaAll | tr '\r' ' ') | cut -d " " -f 5)
-        if [ "$SEMERU_ARCHIVE_WINDOWS_SHA256" != "$downloadedZipSha" ]; then
-            echo "ERROR: expected SHA: $SEMERU_ARCHIVE_WINDOWS_SHA256 is not equal to downloaded file calculated SHA of: $downloadedZipSha"
-            exit -1
-        fi
-        unzip /tmp/liberty-dev-tool-semeru-jdk.zip -d "$SOFTWARE_INSTALL_DIR"
-    fi
-
+	echo "Java Home: ${javaHome}"
+	
 	# Set the JAVA_HOME environment variable and make it available to other steps within the executing job.
 	echo "JAVA_HOME=${javaHome}" >> $GITHUB_ENV
 

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -93,6 +93,45 @@ export async function waitForLanguageServerInit(
 }
 
 /**
+ * Wait for hover widget to appear with content after triggering hover command.
+ * This function dynamically waits for the hover widget to render and contain content,
+ * accounting for language server initialization delays.
+ * Works for both Liberty Language Server and LSP4Jakarta hover content.
+ *
+ * @param driver The WebDriver instance
+ * @param elementDescription Description of the element being hovered (for logging)
+ * @param timeout Timeout in milliseconds (default: 15000)
+ * @returns true if hover widget appeared with content
+ */
+export async function waitForHoverWidget(
+    driver: any,
+    elementDescription: string,
+    timeout: number = 15000
+): Promise<boolean> {
+    const wait = getWaitHelper();
+    
+    return await wait.forCondition(async () => {
+        try {
+            const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
+            const isDisplayed = await hoverWidget.isDisplayed();
+            if (isDisplayed) {
+                const hoverText = await hoverWidget.getText();
+                logger.info(`Hover content for ${elementDescription}: ${hoverText.length} characters`);
+                // Verify hover contains content (language server provides documentation)
+                return hoverText && hoverText.length > 0;
+            }
+        } catch {
+            return false;
+        }
+        return false;
+    }, {
+        timeout: timeout,
+        pollInterval: 500,
+        message: `Hover widget did not appear with content for ${elementDescription}`
+    });
+}
+
+/**
  * @deprecated Use getWaitHelper().sleep() or preferably condition-based waiting instead
  */
 export function delay(millisec: number) {

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -3,7 +3,7 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import path = require('path');
-import { Workbench, InputBox, DefaultTreeItem, ModalDialog, VSBrowser, WaitHelper, BottomBarPanel, OutputView } from 'vscode-extension-tester';
+import { Workbench, InputBox, DefaultTreeItem, ModalDialog, VSBrowser, WaitHelper, BottomBarPanel, OutputView, DebugToolbar } from 'vscode-extension-tester';
 import * as fs from 'fs';
 import { STOP_DASHBOARD_MAC_ACTION } from '../definitions/constants';
 import { MapContextMenuforMac } from './macUtils';
@@ -327,11 +327,9 @@ export async function checkTerminalforServerState(serverStatusCode: string): Pro
             message: `Server state '${serverStatusCode}' not found in terminal`
         });
         
-        await workbench.executeCommand('terminal clear');
         return true;
     } catch (error) {
         logger.error("Failed to find server state in terminal", error);
-        await workbench.executeCommand('terminal clear');
         return false;
     }
 }
@@ -357,11 +355,9 @@ export async function checkTestStatus(testStatus: string): Promise<boolean> {
             message: `Test status '${testStatus}' not found in terminal`
         });
         
-        await workbench.executeCommand('terminal clear');
         return true;
     } catch (error) {
         logger.error("Failed to find test status in terminal", error);
-        await workbench.executeCommand('terminal clear');
         return false;
     }
 }
@@ -475,56 +471,56 @@ export async function waitForServerStop(serverStopString: string): Promise<boole
 /**
  * Wait for test report file to exist on filesystem.
  * Replaces polling loop with condition-based waiting.
+ * @param reportPath Primary report path to check
+ * @param alternatePath Optional alternate report path to check simultaneously
+ * @returns true if report found at either location, false otherwise
  */
-export async function waitForTestReport(reportPath: string): Promise<boolean> {
+export async function waitForTestReport(reportPath: string, alternatePath?: string): Promise<boolean> {
     const wait = getWaitHelper();
     logger.info(`Waiting for test report at: ${reportPath}`);
+    if (alternatePath) {
+        logger.info(`Also checking alternate location: ${alternatePath}`);
+    }
     
     try {
         await wait.forCondition(async () => {
-            return fs.existsSync(reportPath);
+            if (fs.existsSync(reportPath)) {
+                logger.info('Test report found at primary location');
+                return true;
+            }
+            if (alternatePath && fs.existsSync(alternatePath)) {
+                logger.info('Test report found at alternate location');
+                return true;
+            }
+            return;
         }, {
-            timeout: 50000, // 50 seconds
-            pollInterval: 5000, // check every 5 seconds
-            message: `Test report not found at ${reportPath}`
+            timeout: 50000, // 50 seconds max (for slow systems)
+            pollInterval: 1000, // check every 1 second (faster detection)
+            message: alternatePath
+                ? `Test report not found at either ${reportPath} or ${alternatePath}`
+                : `Test report not found at ${reportPath}`
         });
-        logger.info('Test report found');
         return true;
     } catch (error) {
-        logger.info('Report not found at primary location. Checking alternate location...');
+        logger.error('Test report not found');
         return false;
     }
 }
 
 /**
- * Wait for debugger to attach by checking for BREAKPOINTS section.
- * Replaces fixed 8-second delay with condition-based waiting.
+ * Wait for debugger to attach by checking for the DebugToolbar.
+ * The DebugToolbar only appears when a debug session is successfully connected.
  */
-export async function waitForDebuggerAttach(debugView: any): Promise<boolean> {
-    const wait = getWaitHelper();
-    logger.info('Waiting for debugger to attach');
+export async function waitForDebuggerAttach(): Promise<boolean> {
+    logger.info('Waiting for debugger to attach (checking for DebugToolbar)');
     
     try {
-        await wait.forCondition(async () => {
-            const contentPart = debugView.getContent();
-            const sections = await contentPart.getSections();
-            
-            for (const section of sections) {
-                const sectionText = await section.getEnclosingElement().getText();
-                if (sectionText.includes("BREAKPOINTS")) {
-                    logger.info('BREAKPOINTS section found - debugger attached');
-                    return true;
-                }
-            }
-            return;
-        }, {
-            timeout: 30000, // 30 seconds
-            pollInterval: 2000, // check every 2 seconds
-            message: 'Debugger did not attach - BREAKPOINTS section not found'
-        });
+        // Wait for the debug toolbar to appear, which indicates debugger is attached
+        await DebugToolbar.create(30000);
+        logger.info('DebugToolbar appeared - debugger attached successfully');
         return true;
     } catch (error) {
-        logger.error('Failed to detect debugger attachment', error);
+        logger.error('Failed to detect debugger attachment - DebugToolbar did not appear', error);
         return false;
     }
 }

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -3,7 +3,7 @@
  * Copyright IBM Corp. 2023, 2026
  */
 import path = require('path');
-import { Workbench, InputBox, DefaultTreeItem, ModalDialog, VSBrowser, WaitHelper } from 'vscode-extension-tester';
+import { Workbench, InputBox, DefaultTreeItem, ModalDialog, VSBrowser, WaitHelper, BottomBarPanel, OutputView } from 'vscode-extension-tester';
 import * as fs from 'fs';
 import { STOP_DASHBOARD_MAC_ACTION } from '../definitions/constants';
 import { MapContextMenuforMac } from './macUtils';
@@ -23,6 +23,73 @@ export function getWaitHelper(): WaitHelper {
         waitHelper = new WaitHelper(VSBrowser.instance.driver);
     }
     return waitHelper;
+}
+
+/**
+ * Wait for a language server to initialize by checking its output channel.
+ * Uses clipboard to read full output content by clicking in output view to focus it.
+ *
+ * @param channelName The name of the output channel (e.g., 'Language Support for Liberty')
+ * @param initMessage The message to look for indicating initialization (e.g., 'Initialized Liberty Language server')
+ * @param timeout Timeout in seconds (default: 60)
+ */
+export async function waitForLanguageServerInit(
+    channelName: string,
+    initMessage: string,
+    timeout: number = 60
+): Promise<void> {
+    const wait = getWaitHelper();
+    const workbench = new Workbench();
+    
+    logger.info(`Checking if the ${channelName} channel has initialized...`);
+    
+    await wait.forCondition(async () => {
+        try {
+            // Open the bottom bar panel (Output)
+            const bottomBar = new BottomBarPanel();
+            await bottomBar.toggle(true);
+            await wait.sleep(500);
+            
+            // Get the OutputView
+            const outputView = await bottomBar.openOutputView();
+            await wait.sleep(500);
+            
+            // Select the specific output channel
+            await outputView.selectChannel(channelName);
+            await wait.sleep(1000);
+            
+            // Click in the output view to focus it, then use clipboard to get content
+            // This is similar to how terminal content is read in checkTerminalforServerState
+            const outputElement = await outputView.getEnclosingElement();
+            await outputElement.click();
+            await wait.sleep(500);
+            
+            clipboard.writeSync(''); // Clear clipboard
+            await workbench.executeCommand('editor.action.selectAll');
+            await wait.sleep(500);
+            await workbench.executeCommand('editor.action.clipboardCopyAction');
+            await wait.sleep(500);
+            const outputText = clipboard.readSync();
+            
+            // Close the output panel
+            await bottomBar.toggle(false);
+            
+            if (outputText.includes(initMessage)) {
+                logger.info(`${channelName} initialized successfully`);
+                return true;
+            }
+            
+            logger.info(`Waiting for the ${channelName} channel initialization message...`);
+            return false;
+        } catch (error) {
+            logger.info(`Error checking the ${channelName} channel: ${error}, retrying...`);
+            return false;
+        }
+    }, {
+        timeout: timeout * 1000,
+        pollInterval: 2000,
+        message: `The ${channelName} output channel did not initialize within ${timeout} seconds`
+    });
 }
 
 /**

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -447,7 +447,6 @@ export async function clearCommandPalette() {
 
 /**
  * Wait for the Liberty Dashboard to load and become ready.
- * This replaces arbitrary delays with condition-based waiting.
  */
 export async function waitForDashboardToLoad(section: any): Promise<void> {
     const wait = getWaitHelper();
@@ -487,7 +486,6 @@ export async function waitForDashboardToLoad(section: any): Promise<void> {
 
 /**
  * Wait for server to start by checking terminal output.
- * Replaces fixed 30-second delays with condition-based waiting.
  */
 export async function waitForServerStart(serverStartString: string): Promise<boolean> {
     logger.info('Waiting for server to start');
@@ -509,7 +507,6 @@ export async function waitForServerStop(serverStopString: string): Promise<boole
 
 /**
  * Wait for test report file to exist on filesystem.
- * Replaces polling loop with condition-based waiting.
  * @param reportPath Primary report path to check
  * @param alternatePath Optional alternate report path to check simultaneously
  * @returns true if report found at either location, false otherwise
@@ -555,7 +552,8 @@ export async function waitForDebuggerAttach(): Promise<boolean> {
     
     try {
         // Wait for the debug toolbar to appear, which indicates debugger is attached
-        await DebugToolbar.create(30000);
+        const findDebugBarTimeout = 30000;
+        await DebugToolbar.create(findDebugBarTimeout);
         logger.info('DebugToolbar appeared - debugger attached successfully');
         return true;
     } catch (error) {

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -101,16 +101,16 @@ export async function waitForLanguageServerInit(
  * @param driver The WebDriver instance
  * @param elementDescription Description of the element being hovered (for logging)
  * @param timeout Timeout in milliseconds (default: 15000)
- * @returns true if hover widget appeared with content
+ * @returns The hover text content if widget appeared with content, empty string otherwise
  */
 export async function waitForHoverWidget(
     driver: any,
     elementDescription: string,
     timeout: number = 15000
-): Promise<boolean> {
+): Promise<string> {
     const wait = getWaitHelper();
     
-    return await wait.forCondition(async () => {
+    const result = await wait.forCondition(async () => {
         try {
             const hoverWidget = await driver.findElement({ css: '.monaco-hover' });
             const isDisplayed = await hoverWidget.isDisplayed();
@@ -118,17 +118,21 @@ export async function waitForHoverWidget(
                 const hoverText = await hoverWidget.getText();
                 logger.info(`Hover content for ${elementDescription}: ${hoverText.length} characters`);
                 // Verify hover contains content (language server provides documentation)
-                return hoverText && hoverText.length > 0;
+                if (hoverText && hoverText.length > 0) {
+                    return hoverText;
+                }
             }
         } catch {
-            return false;
+            return undefined;
         }
-        return false;
+        return undefined;
     }, {
         timeout: timeout,
         pollInterval: 500,
         message: `Hover widget did not appear with content for ${elementDescription}`
     });
+    
+    return result || '';
 }
 
 /**


### PR DESCRIPTION
- Added tests to check hovers for LCLS and LSP4Jakarta in Maven and Gradle projects
- Checks language servers initialized
- Fixed issue with attached debugger check on VS Code 1.117.0
- Updated test logic to clear terminal after each test rather than per terminal check
- Test report check test case now checks both report path and alternate report path
- Updated JDK install in setup.sh to use Java 21 if no JDK is found on machine, skips install for GHA now