### PR TITLE
Update to Apache HttpComponents and Gradle Wrapper in tests

### DIFF
--- a/src/test/resources/gradle/liberty-gradle-test-wrapper-app/build.gradle
+++ b/src/test/resources/gradle/liberty-gradle-test-wrapper-app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
      
      // test dependencies
      testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
-     testImplementation 'commons-httpclient:commons-httpclient:3.1'
+     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
 
 }
 

--- a/src/test/resources/gradle/liberty-gradle-test-wrapper-app/gradle/wrapper/gradle-wrapper.properties
+++ b/src/test/resources/gradle/liberty-gradle-test-wrapper-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/resources/gradle/liberty-gradle-test-wrapper-app/src/test/java/test/gradle/liberty/web/app/it/EndpointIT.java
+++ b/src/test/resources/gradle/liberty-gradle-test-wrapper-app/src/test/java/test/gradle/liberty/web/app/it/EndpointIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2026 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,30 +15,26 @@ package test.gradle.liberty.web.app.it;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class EndpointIT {
     private String URL = "http://localhost:9080/liberty-gradle-test-wrapper-app/servlet";
 
     @Test
     public void testServlet() throws Exception {
-        System.out.println("am ere");
-        HttpClient client = new HttpClient();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet request = new HttpGet(URL);
+            try (CloseableHttpResponse response = client.execute(request)) {
+                int statusCode = response.getCode();
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-        GetMethod method = new GetMethod(URL);
-
-        try {
-            int statusCode = client.executeMethod(method);
-
-            Assertions.assertEquals(HttpStatus.SC_OK, statusCode, "HTTP GET failed");
-
-            String response = method.getResponseBodyAsString(1000);
-
-            Assertions.assertTrue(response.contains("Hello! How are you today?"), "Unexpected response body");
-        } finally {
-            method.releaseConnection();
-        }  
+                Assertions.assertEquals(HttpStatus.SC_OK, statusCode, "HTTP GET failed");
+                Assertions.assertTrue(responseBody.contains("Hello! How are you today?"), "Unexpected response body");
+            }
+        }
     }
 }

--- a/src/test/resources/gradle/liberty-gradle-test-wrapper-app/src/test/java/test/gradle/liberty/web/app/it/EndpointIT.java
+++ b/src/test/resources/gradle/liberty-gradle-test-wrapper-app/src/test/java/test/gradle/liberty/web/app/it/EndpointIT.java
@@ -13,12 +13,12 @@
 package test.gradle.liberty.web.app.it;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class EndpointIT {

--- a/src/test/resources/maven/liberty-maven-test-wrapper-app/pom.xml
+++ b/src/test/resources/maven/liberty-maven-test-wrapper-app/pom.xml
@@ -19,7 +19,7 @@
     <artifactId>liberty-maven-test-wrapper-app</artifactId>
     <packaging>war</packaging>
     <version>0.0.1-SNAPSHOT</version>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -27,7 +27,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <packaging.type>minify,runnable</packaging.type>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -36,9 +36,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -48,7 +48,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>

--- a/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
+++ b/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
@@ -16,29 +16,29 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+
+import java.net.http.HttpClient;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class EndpointIT {
     private String URL = "http://localhost:9080/liberty-maven-test-wrapper-app/servlet";
 
     @Test
     public void testServlet() throws Exception {
-        HttpClient client = new HttpClient();
-        
-        GetMethod method = new GetMethod(URL);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet request = new HttpGet(URL);
+            try (CloseableHttpResponse response = client.execute(request)) {
+                int statusCode = response.getCode();
+                String responseBody = EntityUtils.toString(response.getEntity());
 
-        try {
-            int statusCode = client.executeMethod(method);
-
-            Assertions.assertEquals(HttpStatus.SC_OK, statusCode, "HTTP GET failed");
-
-            String response = method.getResponseBodyAsString(1000);
-
-            Assertions.assertTrue(response.contains("Hello! How are you today?"), "Unexpected response body");
-        } finally {
-            method.releaseConnection();
-        }  
+                Assertions.assertEquals(HttpStatus.SC_OK, statusCode, "HTTP GET failed");
+                Assertions.assertTrue(responseBody.contains("Hello! How are you today?"), "Unexpected response body");
+            }
+        }
     }
 }

--- a/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
+++ b/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
@@ -13,12 +13,12 @@
 package test.maven.liberty.web.app.it;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class EndpointIT {

--- a/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
+++ b/src/test/resources/maven/liberty-maven-test-wrapper-app/src/test/java/test/maven/liberty/web/app/it/EndpointIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022 IBM Corporation and others.
+* Copyright (c) 2022, 2026 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,10 +15,6 @@ package test.maven.liberty.web.app.it;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-
-import java.net.http.HttpClient;
-
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;


### PR DESCRIPTION
## Description
Commons HttpClient project has ended, and replaced with Apache HttpComponents. This was brought to light by a [Dependabot alert](https://github.com/OpenLiberty/liberty-tools-vscode/security/dependabot/99). 

## Changes
This PR keeps the same functionality of the tests while updating the package used in the Maven and Gradle portion in EndpointIT.

The Gradle wrapper is also updated to support Java 21.