### PR TITLE
Update badge endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 > This page provides an overview of Liberty Tools for Visual Studio Code.
 > For minimum requirements information and detailed instructions on how to use Liberty Tools, check the [user-guide](docs/user-guide.md).
 
-[![Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Open-Liberty.liberty-dev-vscode-ext?style=for-the-badge&label=VS%20Market "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
-[![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?style=for-the-badge&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
+[![Marketplace Version](https://vsmarketplacebadges.dev/version/Open-Liberty.liberty-dev-vscode-ext.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
+[![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?flat&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
 Liberty Tools for Visual Studio Code offers features for developing cloud-native Java applications with [Open Liberty](https://openliberty.io/) and [WebSphere Liberty](https://www.ibm.com/products/websphere-liberty). Iterate fast with Liberty dev mode, code with assistance for MicroProfile & Jakarta EE APIs, and easily edit Liberty configuration files.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 > This page provides an overview of Liberty Tools for Visual Studio Code.
 > For minimum requirements information and detailed instructions on how to use Liberty Tools, check the [user-guide](docs/user-guide.md).
 
-[![Marketplace Version](https://vsmarketplacebadges.dev/version/Open-Liberty.liberty-dev-vscode-ext.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
-[![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode?flat&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
+[![Marketplace Version](https://vsmarketplacebadges.dev/version/Open-Liberty.liberty-dev-vscode-ext.png "Current Release")](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext)
+[![License](https://img.shields.io/github/license/OpenLiberty/liberty-tools-vscode.png?flat&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
 Liberty Tools for Visual Studio Code offers features for developing cloud-native Java applications with [Open Liberty](https://openliberty.io/) and [WebSphere Liberty](https://www.ibm.com/products/websphere-liberty). Iterate fast with Liberty dev mode, code with assistance for MicroProfile & Jakarta EE APIs, and easily edit Liberty configuration files.
 


### PR DESCRIPTION
Updating the marketplace and license badge endpoints:
- Using https://vsmarketplacebadges.dev/
- New Marketplace badge: https://vsmarketplacebadges.dev/version/Open-Liberty.liberty-dev-vscode-ext.svg
- Approved for use by VS: https://github.com/microsoft/vscode-docs/blob/main/api/references/extension-manifest.md#approved-badges

Existing badges:
<img width="424" height="55" alt="Screenshot 2026-06-01 at 09 55 43" src="https://github.com/user-attachments/assets/c56b0160-624a-4d4f-9b5d-1a18c435f60a" />
New Badges:
<img width="355" height="46" alt="Screenshot 2026-06-01 at 09 55 29" src="https://github.com/user-attachments/assets/58e2e699-df7f-49e4-9f5c-25069c8ac09e" />
