### PR TITLE
Automate bootstrap.properties LSP tests and refactor server.env into shared suite

### DIFF
--- a/src/test/MavenBootstrap.ts
+++ b/src/test/MavenBootstrap.ts
@@ -1,0 +1,40 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+import * as utils from './utils/testUtils';
+import { runConfigFileTestSuite } from './shared/configFileTestSuite';
+
+runConfigFileTestSuite({
+    suiteTitle: 'Bootstrap Properties',
+    getProjectPath: utils.getMvnProjectPath,
+    filePathSegments: ['src', 'main', 'liberty', 'config', 'bootstrap.properties'],
+    tabTitle: 'bootstrap.properties',
+    hoverInitialContent: 'com.ibm.ws.logging.log.directory=./logs\ncom.ibm.ws.logging.message.format=SIMPLE\n',
+    hoverCases: [
+        {
+            element: 'com.ibm.ws.logging.log.directory',
+            line: 1,
+            column: 1,
+            expectedDoc: 'The directory that contains the log file.',
+        },
+        {
+            element: 'com.ibm.ws.logging.message.format',
+            line: 2,
+            column: 1,
+            expectedDoc: 'This setting specifies the required format for the messages.log file. Valid values are simple or json format. By default, messageFormat is set to simple.',
+        },
+    ],
+    completion: {
+        trigger: 'com.ibm.ws.logging.con',
+        fullItem: 'com.ibm.ws.logging.console.log.level',
+        value: 'INFO',
+    },
+    diagnostic: {
+        lineToken: 'com.ibm.ws.logging.console.log.level',
+        validValue: 'INFO',
+        diagnosticMessage: 'The value `INVALID` is not valid for the property `com.ibm.ws.logging.console.log.level`.',
+        quickFixLabel: 'Replace value with INFO',
+    },
+});

--- a/src/test/MavenTestLSPServerEnv.ts
+++ b/src/test/MavenTestLSPServerEnv.ts
@@ -3,190 +3,38 @@
  * Copyright IBM Corp. 2026
  */
 
-import * as path from 'path';
-import { logger } from './utils/testLogger';
-import { EditorView, VSBrowser } from 'vscode-extension-tester';
-import { EditorPage } from './pages/EditorPage';
 import * as utils from './utils/testUtils';
-import { expect } from 'chai';
-import { CodeAssistPage } from './pages/CodeAssistPage';
-import { ProblemsPage } from './pages/ProblemsPage';
-import { QuickFixPage } from './pages/QuickFixPage';
-import * as editorUtils from './utils/editorUtils';
+import { runConfigFileTestSuite } from './shared/configFileTestSuite';
 
-const HOVER_INITIAL_CONTENT = 'WLP_USER_DIR=./custom-user-dir\nLOG_DIR=./logs\n';
-
-const HOVER_TEST_CASES = [
-    {
-        element: 'WLP_USER_DIR',
-        line: 1,
-        column: 1,
-        expectedDoc: 'The user or custom configuration directory that is used to store shared and server-specific configuration. See the path_to_liberty/wlp/README.TXT file for details about shared resource locations. A server configuration is at the %WLP_USER_DIR%/servers/serverName location. The default value is the user directory in the installation directory.',
+runConfigFileTestSuite({
+    suiteTitle: 'Server Env',
+    getProjectPath: utils.getMvnProjectPath,
+    filePathSegments: ['src', 'main', 'liberty', 'config', 'server.env'],
+    tabTitle: 'server.env',
+    hoverInitialContent: 'WLP_USER_DIR=./custom-user-dir\nLOG_DIR=./logs\n',
+    hoverCases: [
+        {
+            element: 'WLP_USER_DIR',
+            line: 1,
+            column: 1,
+            expectedDoc: 'The user or custom configuration directory that is used to store shared and server-specific configuration. See the path_to_liberty/wlp/README.TXT file for details about shared resource locations. A server configuration is at the %WLP_USER_DIR%/servers/serverName location. The default value is the user directory in the installation directory.',
+        },
+        {
+            element: 'LOG_DIR',
+            line: 2,
+            column: 1,
+            expectedDoc: 'The directory that contains the log file. The default value is %WLP_OUTPUT_DIR%/serverName/logs',
+        },
+    ],
+    completion: {
+        trigger: 'WLP_LOG',
+        fullItem: 'WLP_LOGGING_MESSAGE_FORMAT',
+        value: 'JSON',
     },
-    {
-        element: 'LOG_DIR',
-        line: 2,
-        column: 1,
-        expectedDoc: 'The directory that contains the log file. The default value is %WLP_OUTPUT_DIR%/serverName/logs',
+    diagnostic: {
+        lineToken: 'WLP_LOGGING_MESSAGE_FORMAT',
+        validValue: 'JSON',
+        diagnosticMessage: 'The value `INVALID` is not valid for the variable `WLP_LOGGING_MESSAGE_FORMAT`.',
+        quickFixLabel: 'Replace value with JSON',
     },
-];
-
-describe('Server Env functionality tests for Maven Project', () => {
-    let serverEnv: EditorPage;
-    let wait: any;
-
-    before(async function() {
-        this.timeout(60000);
-
-        logger.info('Setting up Maven server.env tests');
-
-        await VSBrowser.instance.openResources(utils.getMvnProjectPath());
-        await VSBrowser.instance.waitForWorkbench();
-
-        wait = utils.getWaitHelper();
-
-        logger.info('Opening server.env file for all tests');
-        const serverEnvPath = path.resolve(
-            utils.getMvnProjectPath(),
-            'src', 'main', 'liberty', 'config', 'server.env'
-        );
-        logger.info(`Server.env path: ${serverEnvPath}`);
-
-        serverEnv = await new EditorPage().openFile(serverEnvPath, 'server.env');
-        logger.info('Server.env file opened and editor obtained');
-    });
-
-    afterEach(async function() {
-        if (this.currentTest?.state === 'failed') {
-            await VSBrowser.instance.driver.takeScreenshot();
-            logger.error(`Test failed: ${this.currentTest.title}`);
-        }
-    });
-
-    after(async function() {
-        this.timeout(10000);
-        try {
-            if (serverEnv) {
-                const currentText = await serverEnv.getEditor().getText();
-                try {
-                    await serverEnv.getEditor().selectText(currentText);
-                    await wait.sleep(300);
-                } catch (selectError) {
-                    // selectText may fail but setText still works
-                }
-                await editorUtils.clearEditor(serverEnv.getEditor());
-                logger.info('Reset server.env to empty after tests');
-            }
-        } catch (error) {
-            logger.error('Failed to reset server.env', error);
-        }
-        try {
-            await new EditorView().closeAllEditors();
-            logger.info('Closed all editors after test suite');
-        } catch (error) {
-            logger.error('Failed to close editors in after hook', error);
-        }
-        utils.copyScreenshotsToProjectFolder('maven');
-    });
-
-    it('Liberty Language Server should initialize', async function() {
-        this.timeout(60000);
-        logger.testStart('Liberty Language Server should initialize');
-        try {
-            await utils.waitForLanguageServerInit(
-                'Language Support for Liberty',
-                'Initialized Liberty Language server',
-                60
-            );
-            logger.testComplete('Liberty Language Server initialized successfully');
-        } catch (error) {
-            logger.testFailed('Liberty Language Server should initialize', error);
-            throw error;
-        }
-    });
-
-    HOVER_TEST_CASES.forEach(testCase => {
-        it(`Hover over ${testCase.element} shows Liberty Language Server documentation`, async function() {
-            this.timeout(30000);
-            logger.testStart(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
-            await serverEnv.getEditor().setText(HOVER_INITIAL_CONTENT);
-            await serverEnv.getEditor().save();
-            await wait.sleep(1000);
-
-            try {
-                const hoverText = await editorUtils.hoverOver(serverEnv.getEditor(), testCase.line, testCase.column, testCase.element);
-                expect(hoverText).to.not.be.empty;
-                logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
-
-                logger.step(4, 'Verifying hover contains expected documentation');
-                expect(hoverText).to.include(testCase.expectedDoc);
-                logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
-
-                logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
-            } catch (error) {
-                logger.testFailed(`Hover over ${testCase.element} shows Liberty Language Server documentation`, error);
-                throw error;
-            }
-        });
-    });
-
-    it('server.env WLP_LOG populates correct WLP_LOGGING_MESSAGE_FORMAT type ahead', async function() {
-        this.timeout(275000);
-        logger.testStart('server.env WLP_LOG populates correct WLP_LOGGING_MESSAGE_FORMAT type ahead');
-
-        try {
-            logger.step(1, 'Positioning cursor');
-            await serverEnv.getEditor().setCursor(3, 1);
-
-            logger.step(2, 'Opening content assist');
-            const codeAssist = new CodeAssistPage();
-            await codeAssist.insertSnippet(serverEnv, 'WLP_LOG', 'WLP_LOGGING_MESSAGE_FORMAT');
-            logger.stepSuccess(2, 'Completion inserted');
-            const after = await serverEnv.getEditor().getText();
-            expect(after).to.include('WLP_LOGGING_MESSAGE_FORMAT');
-            await wait.sleep(1000);
-
-            const lineText = await serverEnv.getEditor().getTextAtLine(3);
-            await serverEnv.getEditor().setTextAtLine(3, lineText.trimEnd() + '=JSON');
-
-            await serverEnv.getEditor().save();
-            await wait.sleep(500);
-
-            logger.testComplete('server.env WLP_LOG populates correct WLP_LOGGING_MESSAGE_FORMAT completion');
-        } catch (error) {
-            logger.testFailed('server.env WLP_LOG populates correct WLP_LOGGING_MESSAGE_FORMAT completion', error);
-            throw error;
-        }
-    });
-
-    it('Show that INVALID text displays diagnostic and quick fix removes it', async function() {
-        this.timeout(90000);
-        logger.testStart('Show that INVALID text displays diagnostic and quick fix removes it');
-        try {
-            await editorUtils.replaceTextWithinLineContaining(serverEnv.getEditor(), 'WLP_LOGGING_MESSAGE_FORMAT', 'JSON', 'INVALID');
-
-            await serverEnv.getEditor().save();
-            await wait.sleep(500);
-
-            const problems = new ProblemsPage();
-            const found = await problems.hasDiagnostic('The value `INVALID` is not valid for the variable `WLP_LOGGING_MESSAGE_FORMAT`.');
-            expect(found).to.be.true;
-            logger.testComplete('Diagnostic shows INVALID variable');
-
-            const buffer = await serverEnv.getEditor().getText();
-            logger.info('Buffer before quick fix: ' + JSON.stringify(buffer));
-
-            await new QuickFixPage().applyFix(serverEnv, 'INVALID', 'Replace value with JSON');
-            await wait.sleep(3000);
-            await serverEnv.getEditor().save();
-            await wait.sleep(5000);
-
-            const afterFix = await serverEnv.getEditor().getText();
-            expect(afterFix).to.include('JSON');
-            expect(await problems.hasDiagnostic('The value `INVALID` is not valid for the variable `WLP_LOGGING_MESSAGE_FORMAT`.')).to.be.false;
-        } catch (error) {
-            logger.testFailed('Diagnostic/quick-fix test flow failed', error);
-            throw error;
-        }
-    });
 });

--- a/src/test/shared/configFileTestSuite.ts
+++ b/src/test/shared/configFileTestSuite.ts
@@ -1,0 +1,224 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+import * as path from 'path';
+import { logger } from '../utils/testLogger';
+import { EditorView, VSBrowser } from 'vscode-extension-tester';
+import { EditorPage } from '../pages/EditorPage';
+import * as utils from '../utils/testUtils';
+import { expect } from 'chai';
+import { CodeAssistPage } from '../pages/CodeAssistPage';
+import { ProblemsPage } from '../pages/ProblemsPage';
+import { QuickFixPage } from '../pages/QuickFixPage';
+import * as editorUtils from '../utils/editorUtils';
+
+export interface HoverCase {
+    element: string;
+    line: number;
+    column: number;
+    expectedDoc: string;
+}
+
+export interface CompletionConfig {
+    /** Text to type to trigger the completion. */
+    trigger: string;
+    /** Full item label to select from the completion list. */
+    fullItem: string;
+    /** Value to append after `=` once the key is inserted. */
+    value: string;
+}
+
+export interface DiagnosticConfig {
+    /** Token on the completed line used to locate it (usually the key name). */
+    lineToken: string;
+    /** The valid value that was set during completion. */
+    validValue: string;
+    /** The expected diagnostic message when the value is replaced with INVALID. */
+    diagnosticMessage: string;
+    /** The quick-fix label to apply (e.g. 'Replace value with JSON'). */
+    quickFixLabel: string;
+}
+
+export interface ConfigFileTestConfig {
+    /** Human-readable suite title, e.g. 'Server Env' or 'Bootstrap Properties'. */
+    suiteTitle: string;
+    /** Function that returns the project root path. */
+    getProjectPath: () => string;
+    /** Config-relative file path segments, e.g. ['src','main','liberty','config','server.env']. */
+    filePathSegments: string[];
+    /** Tab title shown in the VS Code editor (usually the file name). */
+    tabTitle: string;
+    /** Initial file content written before each hover test. */
+    hoverInitialContent: string;
+    /** Two hover test cases. */
+    hoverCases: [HoverCase, HoverCase];
+    /** Completion test config. */
+    completion: CompletionConfig;
+    /** Diagnostic + quick-fix test config (runs after completion, reuses its line). */
+    diagnostic: DiagnosticConfig;
+}
+
+export function runConfigFileTestSuite(config: ConfigFileTestConfig): void {
+    describe(`${config.suiteTitle} functionality tests for Maven Project`, () => {
+        let editor: EditorPage;
+        let wait: any;
+
+        before(async function () {
+            this.timeout(60000);
+            logger.info(`Setting up Maven ${config.tabTitle} tests`);
+
+            await VSBrowser.instance.openResources(config.getProjectPath());
+            await VSBrowser.instance.waitForWorkbench();
+
+            wait = utils.getWaitHelper();
+
+            const filePath = path.resolve(config.getProjectPath(), ...config.filePathSegments);
+            logger.info(`${config.tabTitle} path: ${filePath}`);
+
+            editor = await new EditorPage().openFile(filePath, config.tabTitle);
+            logger.info(`${config.tabTitle} file opened and editor obtained`);
+        });
+
+        afterEach(async function () {
+            if (this.currentTest?.state === 'failed') {
+                await VSBrowser.instance.driver.takeScreenshot();
+                logger.error(`Test failed: ${this.currentTest.title}`);
+            }
+        });
+
+        after(async function () {
+            this.timeout(10000);
+            try {
+                if (editor) {
+                    const currentText = await editor.getEditor().getText();
+                    try {
+                        await editor.getEditor().selectText(currentText);
+                        await wait.sleep(300);
+                    } catch {
+                        // selectText may fail but setText still works
+                    }
+                    await editorUtils.clearEditor(editor.getEditor());
+                    logger.info(`Reset ${config.tabTitle} to empty after tests`);
+                }
+            } catch (error) {
+                logger.error(`Failed to reset ${config.tabTitle}`, error);
+            }
+            try {
+                await new EditorView().closeAllEditors();
+                logger.info('Closed all editors after test suite');
+            } catch (error) {
+                logger.error('Failed to close editors in after hook', error);
+            }
+            utils.copyScreenshotsToProjectFolder('maven');
+        });
+
+        it('Liberty Language Server should initialize', async function () {
+            this.timeout(60000);
+            logger.testStart('Liberty Language Server should initialize');
+            try {
+                await utils.waitForLanguageServerInit(
+                    'Language Support for Liberty',
+                    'Initialized Liberty Language server',
+                    60
+                );
+                logger.testComplete('Liberty Language Server initialized successfully');
+            } catch (error) {
+                logger.testFailed('Liberty Language Server should initialize', error);
+                throw error;
+            }
+        });
+
+        config.hoverCases.forEach(testCase => {
+            it(`Hover over ${testCase.element} shows Liberty Language Server documentation`, async function () {
+                this.timeout(30000);
+                logger.testStart(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+                await editor.getEditor().setText(config.hoverInitialContent);
+                await editor.getEditor().save();
+                await wait.sleep(1000);
+
+                try {
+                    const hoverText = await editorUtils.hoverOver(editor.getEditor(), testCase.line, testCase.column, testCase.element);
+                    expect(hoverText).to.not.be.empty;
+                    logger.stepSuccess(3, `Hover widget displayed with Liberty Language Server content for ${testCase.element}`);
+
+                    logger.step(4, 'Verifying hover contains expected documentation');
+                    expect(hoverText).to.include(testCase.expectedDoc);
+                    logger.stepSuccess(4, `Hover text contains expected documentation: "${testCase.expectedDoc}"`);
+
+                    logger.testComplete(`Hover over ${testCase.element} shows Liberty Language Server documentation`);
+                } catch (error) {
+                    logger.testFailed(`Hover over ${testCase.element} shows Liberty Language Server documentation`, error);
+                    throw error;
+                }
+            });
+        });
+
+        it(`${config.tabTitle} ${config.completion.trigger} populates correct ${config.completion.fullItem} type ahead`, async function () {
+            this.timeout(275000);
+            logger.testStart(`${config.tabTitle} ${config.completion.trigger} populates correct ${config.completion.fullItem} type ahead`);
+
+            try {
+                logger.step(1, 'Positioning cursor at end of file');
+                await editor.getEditor().setCursor(3, 1);
+
+                logger.step(2, 'Opening content assist');
+                const codeAssist = new CodeAssistPage();
+                await codeAssist.insertSnippet(editor, config.completion.trigger, config.completion.fullItem);
+                logger.stepSuccess(2, 'Completion inserted');
+
+                const after = await editor.getEditor().getText();
+                expect(after).to.include(config.completion.fullItem);
+                await wait.sleep(1000);
+
+                const lineText = await editor.getEditor().getTextAtLine(3);
+                await editor.getEditor().setTextAtLine(3, lineText.trimEnd() + `=${config.completion.value}`);
+
+                await editor.getEditor().save();
+                await wait.sleep(500);
+
+                logger.testComplete(`${config.tabTitle} ${config.completion.trigger} populates correct ${config.completion.fullItem} completion`);
+            } catch (error) {
+                logger.testFailed(`${config.tabTitle} ${config.completion.trigger} populates correct ${config.completion.fullItem} completion`, error);
+                throw error;
+            }
+        });
+
+        it('Show that INVALID text displays diagnostic and quick fix removes it', async function () {
+            this.timeout(90000);
+            logger.testStart('Show that INVALID text displays diagnostic and quick fix removes it');
+            try {
+                await editorUtils.replaceTextWithinLineContaining(
+                    editor.getEditor(),
+                    config.diagnostic.lineToken,
+                    config.diagnostic.validValue,
+                    'INVALID'
+                );
+
+                await editor.getEditor().save();
+                await wait.sleep(500);
+
+                const problems = new ProblemsPage();
+                const found = await problems.hasDiagnostic(config.diagnostic.diagnosticMessage);
+                expect(found).to.be.true;
+                logger.testComplete('Diagnostic shows INVALID value');
+
+                const buffer = await editor.getEditor().getText();
+                logger.info('Buffer before quick fix: ' + JSON.stringify(buffer));
+
+                await new QuickFixPage().applyFix(editor, 'INVALID', config.diagnostic.quickFixLabel);
+                await wait.sleep(3000);
+                await editor.getEditor().save();
+                await wait.sleep(5000);
+
+                const afterFix = await editor.getEditor().getText();
+                expect(afterFix).to.include(config.diagnostic.validValue);
+                expect(await problems.hasDiagnostic(config.diagnostic.diagnosticMessage)).to.be.false;
+            } catch (error) {
+                logger.testFailed('Diagnostic/quick-fix test flow failed', error);
+                throw error;
+            }
+        });
+    });
+}


### PR DESCRIPTION
Closes: #438 

## Description:

This PR implements automated UI tests for Liberty Language Server support in bootstrap.properties, and refactors the existing server.env tests to eliminate duplication via a shared test suite.

New: bootstrap.properties test coverage
Adds MavenBootstrap.ts covering the three LSP features called out in #438:

1. Hover (#425 ) verifies hover documentation for com.ibm.ws.logging.log.directory and com.ibm.ws.logging.message.format
2. Completion (#423 ) types com.ibm.ws.logging.con, selects com.ibm.ws.logging.console.log.level from the completion list, and appends =INFO
3. Diagnostic + quick fix (#426 ) replaces the valid value with INVALID, asserts the error marker appears, applies the quick fix, and verifies the diagnostic clears

Also added the seed file bootstrap.properties to the Maven test project with relative paths 

Refactor: shared configFileTestSuite
Both server.env and bootstrap.properties follow the exact same test structure (2 hovers, 1 completion, 1 diagnostic+quickfix). Extracted into src/test/shared/configFileTestSuite.ts as a fully parameterized runConfigFileTestSuite() function. 