### PR TITLE
Add rest snippet tests back to check for passing tests

### DIFF
--- a/.mocharc.unit.yml
+++ b/.mocharc.unit.yml
@@ -1,0 +1,4 @@
+require: ts-node/register
+spec: src/test/unit/**/*.test.ts
+timeout: 5000
+experimental-require-module: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/mocha": "10.0.0",
 				"@types/node": "20.0.0",
 				"@types/selenium-webdriver": "4.1.22",
+				"@types/sinon": "^21.0.1",
 				"@types/vscode": "1.42.0",
 				"@typescript-eslint/eslint-plugin": "8.0.0",
 				"@typescript-eslint/parser": "8.0.0",
@@ -40,7 +41,9 @@
 				"gulp-xml": "1.0.5",
 				"minimatch": "9.0.7",
 				"mocha": "11.7.6",
+				"sinon": "^22.0.0",
 				"ts-loader": "9.5.7",
+				"ts-node": "^10.9.2",
 				"typescript": "6.0.3",
 				"vscode-extension-tester": "8.21.0",
 				"webpack": "5.107.0",
@@ -276,6 +279,30 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40cspotcode%2Fsource-map-support%2F-%2Fsource-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jridgewell%2Ftrace-mapping%2F-%2Ftrace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -1114,6 +1141,47 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/commons/-/commons-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Fcommons%2F-%2Fcommons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/commons/node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/type-detect/-/type-detect-4.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-detect%2F-%2Ftype-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "15.4.0",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Ffake-timers%2F-%2Ffake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@sinonjs/samsam": {
+			"version": "10.0.2",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/samsam/-/samsam-10.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Fsamsam%2F-%2Fsamsam-10.0.2.tgz",
+			"integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1",
+				"type-detect": "^4.1.0"
+			}
+		},
 		"node_modules/@textlint/ast-node-types": {
 			"version": "15.7.1",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
@@ -1174,6 +1242,34 @@
 			"dependencies": {
 				"@textlint/ast-node-types": "15.7.1"
 			}
+		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.12",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node10/-/node10-1.0.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode10%2F-%2Fnode10-1.0.12.tgz",
+			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node12/-/node12-1.0.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode12%2F-%2Fnode12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node14/-/node14-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode14%2F-%2Fnode14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node16/-/node16-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode16%2F-%2Fnode16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
 			"version": "4.3.4",
@@ -1260,6 +1356,23 @@
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.2.tgz",
 			"integrity": "sha512-WrIesso5O0K9S/T87Uct2AvmEFqul11PnprQ98BZEyWILz8QYJt6/tlmqSOVKLNUtAgYHU7D9WGsOFVDb35nPA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/sinon": {
+			"version": "21.0.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@types/sinon/-/sinon-21.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fsinon%2F-%2Fsinon-21.0.1.tgz",
+			"integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/sinonjs__fake-timers": "*"
+			}
+		},
+		"node_modules/@types/sinonjs__fake-timers": {
+			"version": "15.0.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fsinonjs__fake-timers%2F-%2Fsinonjs__fake-timers-15.0.1.tgz",
+			"integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
@@ -2042,6 +2155,19 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.5",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/acorn-walk/-/acorn-walk-8.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-walk%2F-%2Facorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2219,6 +2345,13 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT"
+		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/arg/-/arg-4.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farg%2F-%2Farg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/argparse": {
@@ -3372,6 +3505,13 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/create-require/-/create-require-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcreate-require%2F-%2Fcreate-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6638,6 +6778,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/make-error/-/make-error-1.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmake-error%2F-%2Fmake-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -9390,6 +9537,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/sinon": {
+			"version": "22.0.0",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/sinon/-/sinon-22.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsinon%2F-%2Fsinon-22.0.0.tgz",
+			"integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1",
+				"@sinonjs/fake-timers": "^15.4.0",
+				"@sinonjs/samsam": "^10.0.2",
+				"diff": "^9.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/sinon"
+			}
+		},
+		"node_modules/sinon/node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/diff/-/diff-9.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10548,6 +10722,60 @@
 				"webpack": "^5.0.0"
 			}
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/ts-node/-/ts-node-10.9.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fts-node%2F-%2Fts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-node/node_modules/diff": {
+			"version": "4.0.4",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/diff/-/diff-4.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10872,6 +11100,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-compile-cache-lib%2F-%2Fv8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11824,6 +12059,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/yn/-/yn-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyn%2F-%2Fyn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,7 @@
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40cspotcode%2Fsource-map-support%2F-%2Fsource-map-support-0.8.1.tgz",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
 			"license": "MIT",
@@ -296,7 +296,7 @@
 		},
 		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.9",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40jridgewell%2Ftrace-mapping%2F-%2Ftrace-mapping-0.3.9.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"license": "MIT",
@@ -1143,7 +1143,7 @@
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/commons/-/commons-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Fcommons%2F-%2Fcommons-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
 			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -1153,7 +1153,7 @@
 		},
 		"node_modules/@sinonjs/commons/node_modules/type-detect": {
 			"version": "4.0.8",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/type-detect/-/type-detect-4.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-detect%2F-%2Ftype-detect-4.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
 			"license": "MIT",
@@ -1163,7 +1163,7 @@
 		},
 		"node_modules/@sinonjs/fake-timers": {
 			"version": "15.4.0",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Ffake-timers%2F-%2Ffake-timers-15.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
 			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -1173,7 +1173,7 @@
 		},
 		"node_modules/@sinonjs/samsam": {
 			"version": "10.0.2",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@sinonjs/samsam/-/samsam-10.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sinonjs%2Fsamsam%2F-%2Fsamsam-10.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
 			"integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -1245,28 +1245,28 @@
 		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.12",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node10/-/node10-1.0.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode10%2F-%2Fnode10-1.0.12.tgz",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
 			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node12/-/node12-1.0.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode12%2F-%2Fnode12-1.0.11.tgz",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node14/-/node14-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode14%2F-%2Fnode14-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.4",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@tsconfig/node16/-/node16-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40tsconfig%2Fnode16%2F-%2Fnode16-1.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
 			"dev": true,
 			"license": "MIT"
@@ -1360,7 +1360,7 @@
 		},
 		"node_modules/@types/sinon": {
 			"version": "21.0.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@types/sinon/-/sinon-21.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fsinon%2F-%2Fsinon-21.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
 			"integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
 			"dev": true,
 			"license": "MIT",
@@ -1370,7 +1370,7 @@
 		},
 		"node_modules/@types/sinonjs__fake-timers": {
 			"version": "15.0.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fsinonjs__fake-timers%2F-%2Fsinonjs__fake-timers-15.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
 			"integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
 			"dev": true,
 			"license": "MIT"
@@ -2157,7 +2157,7 @@
 		},
 		"node_modules/acorn-walk": {
 			"version": "8.3.5",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/acorn-walk/-/acorn-walk-8.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-walk%2F-%2Facorn-walk-8.3.5.tgz",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
 			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"dev": true,
 			"license": "MIT",
@@ -2349,7 +2349,7 @@
 		},
 		"node_modules/arg": {
 			"version": "4.1.3",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/arg/-/arg-4.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farg%2F-%2Farg-4.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true,
 			"license": "MIT"
@@ -3510,7 +3510,7 @@
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/create-require/-/create-require-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcreate-require%2F-%2Fcreate-require-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
 			"license": "MIT"
@@ -6780,7 +6780,7 @@
 		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/make-error/-/make-error-1.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmake-error%2F-%2Fmake-error-1.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true,
 			"license": "ISC"
@@ -9539,7 +9539,7 @@
 		},
 		"node_modules/sinon": {
 			"version": "22.0.0",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/sinon/-/sinon-22.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsinon%2F-%2Fsinon-22.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
 			"integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -9556,7 +9556,7 @@
 		},
 		"node_modules/sinon/node_modules/diff": {
 			"version": "9.0.0",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/diff/-/diff-9.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-9.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
 			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -10724,7 +10724,7 @@
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/ts-node/-/ts-node-10.9.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fts-node%2F-%2Fts-node-10.9.2.tgz",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
@@ -10768,7 +10768,7 @@
 		},
 		"node_modules/ts-node/node_modules/diff": {
 			"version": "4.0.4",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/diff/-/diff-4.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-4.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
 			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
@@ -11105,7 +11105,7 @@
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-compile-cache-lib%2F-%2Fv8-compile-cache-lib-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
 			"license": "MIT"
@@ -12063,7 +12063,7 @@
 		},
 		"node_modules/yn": {
 			"version": "3.1.1",
-			"resolved": "https://eu.artifactory.swg-devops.com/artifactory/api/npm/hyc-wasliberty-team-wca4eja-npm-virtual/yn/-/yn-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyn%2F-%2Fyn-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true,
 			"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -253,16 +253,19 @@
 		"buildJakarta": "gulp buildJakartaJdt buildJakartaLs",
 		"test": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/*.js' --code_settings src/test/resources/settings.json",
 		"test-maven": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/M*.js' --code_settings src/test/resources/settings.json",
-		"test-gradle": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/G*.js' --code_settings src/test/resources/settings.json"
+		"test-gradle": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/G*.js' --code_settings src/test/resources/settings.json",
+		"test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node --require ts-node/register node_modules/.bin/mocha --config .mocharc.unit.yml"
 	},
 	"devDependencies": {
 		"@types/chai": "4.3.4",
 		"@types/mocha": "10.0.0",
 		"@types/node": "20.0.0",
 		"@types/selenium-webdriver": "4.1.22",
+		"@types/sinon": "^21.0.1",
 		"@types/vscode": "1.42.0",
 		"@typescript-eslint/eslint-plugin": "8.0.0",
 		"@typescript-eslint/parser": "8.0.0",
+		"@vscode/test-electron": "2.4.0",
 		"axios": "1.16.0",
 		"chai": "4.3.7",
 		"clipboardy": "2.3.0",
@@ -272,14 +275,15 @@
 		"gulp": "5.0.1",
 		"gulp-download2": "1.1.0",
 		"gulp-xml": "1.0.5",
+		"minimatch": "9.0.7",
 		"mocha": "11.7.6",
+		"sinon": "^22.0.0",
 		"ts-loader": "9.5.7",
+		"ts-node": "^10.9.2",
 		"typescript": "6.0.3",
 		"vscode-extension-tester": "8.21.0",
-		"@vscode/test-electron": "2.4.0",
 		"webpack": "5.107.0",
 		"webpack-cli": "5.0.0",
-		"minimatch": "9.0.7",
 		"xml2js": "0.5.0"
 	},
 	"overrides": {

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
 		"test": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/*.js' --code_settings src/test/resources/settings.json",
 		"test-maven": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/M*.js' --code_settings src/test/resources/settings.json",
 		"test-gradle": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/G*.js' --code_settings src/test/resources/settings.json",
-		"test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node --require ts-node/register node_modules/.bin/mocha --config .mocharc.unit.yml"
+		"test-unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node --require ts-node/register node_modules/.bin/mocha --config .mocharc.unit.yml"
 	},
 	"devDependencies": {
 		"@types/chai": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
 		"test": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/*.js' --code_settings src/test/resources/settings.json",
 		"test-maven": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/M*.js' --code_settings src/test/resources/settings.json",
 		"test-gradle": "npm run test-compile && extest setup-and-run -o .vscode/settings.json 'out/test/G*.js' --code_settings src/test/resources/settings.json",
-		"test-unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node --require ts-node/register node_modules/.bin/mocha --config .mocharc.unit.yml"
+		"test-unit": "node node_modules/.bin/mocha --config .mocharc.unit.yml"
 	},
 	"devDependencies": {
 		"@types/chai": "4.3.4",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     item.tooltip = localize("liberty.ls.starting");
     toggleItem(window.activeTextEditor, item);
 
+    // Run after getJavaExtensionAPI so VS Code APIs (findFiles etc.) are ready,
+    // but before startLangServer so we don't wait for LS startup.
+    handleWorkspaceSaveInProgress(context).catch(err => console.error('[handleWorkspaceSaveInProgress] uncaught error:', err));
+
     resolveLclsRequirements(api).then().catch((error => {
         window.showErrorMessage(error.message, error.label).then((selection) => {
             if (error.label && error.label === selection && error.openUrl) {
@@ -60,7 +64,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             item.text = localize("liberty.ls.thumbs.up");
             item.tooltip = localize("liberty.ls.started");
             toggleItem(window.activeTextEditor, item);
-            handleWorkspaceSaveInProgress(context);
             registerCommands(context);
         }, (error: any) => {
             console.log("Liberty client was not ready. Did not initialize");
@@ -107,6 +110,10 @@ function registerCommands(context: ExtensionContext) {
     if (vscode.workspace.workspaceFolders !== undefined) {
         registerFileWatcher(projectProvider);
         vscode.window.registerTreeDataProvider("liberty-dev", projectProvider);
+        // Re-run refresh so that any project written to workspaceState by
+        // handleWorkspaceSaveInProgress (which ran before the tree was registered)
+        // is picked up and displayed immediately.
+        projectProvider.refresh();
     }
 
     context.subscriptions.push(
@@ -303,13 +310,21 @@ async function getJavaExtensionAPI(): Promise<JavaExtensionAPI> {
     return Promise.resolve(api);
 }
 
-function handleWorkspaceSaveInProgress(context: vscode.ExtensionContext) {
-    let projectProvider = getProjectProvider(context);
-    if (projectProvider.getContext().globalState.get('workspaceSaveInProgress') &&
-        projectProvider.getContext().globalState.get('selectedProject') !== undefined) {
-        devCommands.addProjectsToTheDashBoard(projectProvider, projectProvider.getContext().globalState.get('selectedProject') as string);
+async function handleWorkspaceSaveInProgress(context: vscode.ExtensionContext): Promise<boolean> {
+    const projectProvider = getProjectProvider(context);
+    const wip = projectProvider.getContext().globalState.get('workspaceSaveInProgress');
+    const sel = projectProvider.getContext().globalState.get('selectedProject');
+    if (wip && sel !== undefined) {
+        // Wait for the initial refresh() to finish so the project map is fully populated.
+        await projectProvider.initialRefresh;
+        // Write the project into workspaceState. Do NOT call fireChangeEvent here —
+        // the tree data provider may not be registered yet. registerCommands() will
+        // call refresh() after registering the tree, which will display it.
+        await projectProvider.addUserSelectedPath(sel as string, projectProvider.getProjects());
         helperUtil.clearDataSavedInGlobalState(projectProvider.getContext());
+        return true;
     }
+    return false;
 }
 
 function getProjectProvider(context: vscode.ExtensionContext): ProjectProvider {

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -9,7 +9,7 @@ import * as gradleUtil from "../util/gradleUtil";
 import * as mavenUtil from "../util/mavenUtil";
 import * as util from "../util/helperUtil";
 import { localize } from "../util/i18nUtil";
-import { EXCLUDED_DIR_PATTERN, LIBERTY_GRADLE_PROJECT, LIBERTY_GRADLE_PROJECT_CONTAINER, LIBERTY_MAVEN_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, UNTITLED_WORKSPACE } from "../definitions/constants";
+import { EXCLUDED_DIR_PATTERN, LIBERTY_GRADLE_PROJECT, LIBERTY_GRADLE_PROJECT_CONTAINER, LIBERTY_MAVEN_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER } from "../definitions/constants";
 import { BuildFileImpl, GradleBuildFile } from "../util/buildFile";
 import { DashboardData } from "./dashboard";
 import { BaseLibertyProject } from "./baseLibertyProject";
@@ -31,11 +31,15 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 
 	private _context: vscode.ExtensionContext;
 
+	// Resolves when the first refresh() completes. Callers that need a stable
+	// project map before acting (e.g. handleWorkspaceSaveInProgress) must await this.
+	public readonly initialRefresh: Promise<void>;
+
 	constructor(context: vscode.ExtensionContext) {
 		this._context = context;
 		this._onDidChangeTreeData = new vscode.EventEmitter<LibertyProject | undefined>();
 		this.onDidChangeTreeData = this._onDidChangeTreeData.event;
-		this.refresh();
+		this.initialRefresh = this.refresh();
 	}
 
 	public getContext(): vscode.ExtensionContext {
@@ -212,20 +216,20 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 					'Save Workspace'
 				).then(async (selection) => {
 					if (selection === 'Save Workspace') {
+							await this._context.globalState.update('workspaceSaveInProgress', true);
+							console.log('[checkUntitledWorkspaceAndSaveIt] wrote workspaceSaveInProgress=true, selectedProject=' + this._context.globalState.get('selectedProject'));
+							// Do NOT clear globalState here: the new session needs workspaceSaveInProgress
+							// and selectedProject to restore the manually-added project to the dashboard.
+							await vscode.commands.executeCommand('workbench.action.saveWorkspaceAs');
+							console.log('[checkUntitledWorkspaceAndSaveIt] saveWorkspaceAs command returned');
+					} else {
 						/**
-						 * setting workspaceSaveInProgress to true and storing it in globalstate for identifyting that the
-						 * workspace is saved and needs to save the manually added projects to the dashboard
+						 * If the user cancels saving the workspace and exits without saving, the data stays in the global state,
+						 * which is shared across all VS Code instances. To prevent this data from being mistakenly used in other
+						 * sessions and added to the dashboard, it should be cleared if the user cancels the save.
 						 */
-						await this._context.globalState.update('workspaceSaveInProgress', true);
-						//opens the saveWorkspace as dialog box
-						await vscode.commands.executeCommand('workbench.action.saveWorkspaceAs');
+						util.clearDataSavedInGlobalState(this._context);
 					}
-					/**
-					 * If the user cancels saving the workspace and exits without saving, the data stays in the global state, 
-					 * which is shared across all VS Code instances. To prevent this data from being mistakenly used in other 
-					 * sessions and added to the dashboard, it should be cleared if the user cancels the save.
-					 */
-					util.clearDataSavedInGlobalState(this._context);
 					resolve();
 				});
 			} catch (error) {
@@ -237,12 +241,15 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 	}
 
 	/*
-	This method identifies a workspace that is untitled and contains more than one project 
-	*/
+	 * Returns true when the workspace has not yet been saved to a .code-workspace file,
+	 * meaning workspaceState will be lost if the user does "Save Workspace As...".
+	 * This covers both plain single-folder windows (workspace.name == folder name)
+	 * and VS Code's auto-created "Untitled (Workspace)" multi-root workspaces.
+	 */
 	public isMultiProjectUntitledWorkspace(): boolean {
 		const workspaceFolders = vscode.workspace.workspaceFolders;
-		if ((workspaceFolders && workspaceFolders.length > 1
-			&& vscode.workspace.name === UNTITLED_WORKSPACE)) {
+		if (workspaceFolders && workspaceFolders.length >= 1
+			&& vscode.workspace.workspaceFile === undefined) {
 			return true;
 		}
 		return false;

--- a/src/test/GradleTestLSPRestSnippetAndDiagnostic.ts
+++ b/src/test/GradleTestLSPRestSnippetAndDiagnostic.ts
@@ -1,0 +1,9 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+import * as utils from './utils/testUtils';
+import { runRestSnippetSuite } from './shared/restSnippetSuite';
+
+runRestSnippetSuite({ buildTool: 'gradle', getProjectPath: utils.getGradleProjectPath });

--- a/src/test/MavenTestLSPRestSnippetAndDiagnostic.ts
+++ b/src/test/MavenTestLSPRestSnippetAndDiagnostic.ts
@@ -1,0 +1,9 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+import * as utils from './utils/testUtils';
+import { runRestSnippetSuite } from './shared/restSnippetSuite';
+
+runRestSnippetSuite({ buildTool: 'maven', getProjectPath: utils.getMvnProjectPath });

--- a/src/test/unit/addProjectsToTheDashBoard.test.ts
+++ b/src/test/unit/addProjectsToTheDashBoard.test.ts
@@ -1,3 +1,8 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
 // This test runs in plain Node, not inside a real VS Code window.
 // The extension's localization helper expects this env var to exist during import.
 process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });

--- a/src/test/unit/addProjectsToTheDashBoard.test.ts
+++ b/src/test/unit/addProjectsToTheDashBoard.test.ts
@@ -4,75 +4,28 @@
  */
 
 // This test runs in plain Node, not inside a real VS Code window.
-// The extension's localization helper expects this env var to exist during import.
-process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });
-
-// Intercept module loading so we can replace VS Code and localization imports
-// with tiny fakes that are easy to reason about in a unit test.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Module = require("module");
-const originalLoad = Module._load;
-
-// Fake localization helper.
-// Instead of reading translation files, return a predictable string that includes:
-//   1. the message key the command asked for
-//   2. the selected project path passed into localize()
-// Example result: "add.project.manually.message.0:/my/project"
-const localizeStub = (key: string, selection: string) => `${key}:${selection}`;
-
-// Return a tiny fake module whenever production code imports "vscode" or the i18n helper.
-// devCommands.ts imports libertyProject.ts, and that file defines classes that extend
-// vscode.TreeItem and create vscode.EventEmitter instances. So this fake must include
-// enough of the VS Code API for those imports to load successfully.
-Module._load = function(request: string, ...args: any[]) {
-    if (request === "vscode") {
-        return {
-            EventEmitter: class { event = () => {}; fire() {} },
-            TreeItemCollapsibleState: { None: 0 },
-            TreeItem: class {
-                label: string;
-                collapsibleState: number;
-                tooltip?: string;
-                constructor(label: string, collapsibleState?: number) {
-                    this.label = label;
-                    this.collapsibleState = collapsibleState ?? 0;
-                }
-            },
-            Uri: { file: (p: string) => ({ fsPath: p }) },
-            window: {
-                showInformationMessage: showInformationMessageStub,
-                setStatusBarMessage: () => ({ dispose() {} })
-            }
-        };
-    }
-    if (request.endsWith("/util/i18nUtil") || request === "../util/i18nUtil") {
-        return {
-            localize: localizeStub
-        };
-    }
-    return originalLoad.call(this, request, ...args);
-};
-
-import * as assert from "assert";
+import { installFakeVscode } from "./fakeVscode";
 import * as sinon from "sinon";
 
-// Keep one shared reference to the fake VS Code message API.
-// The fake vscode module below returns this same stub, so each test can inspect
-// whether addProjectsToTheDashBoard() asked VS Code to show the expected message.
+// Keep one shared reference to the fake VS Code message API so each test can
+// inspect whether addProjectsToTheDashBoard() asked VS Code to show the right message.
 const showInformationMessageStub = sinon.stub();
 
+// Install the shared vscode fake, must happen before any extension imports.
+// Pass our sinon stub so the fake window.showInformationMessage is observable.
+installFakeVscode({ showInformationMessage: showInformationMessageStub });
+
+import * as assert from "assert";
 import { addProjectsToTheDashBoard } from "../../liberty/devCommands";
 
 describe("addProjectsToTheDashBoard", () => {
 
     afterEach(() => {
-        // Reset call history on the shared message stub between tests.
         showInformationMessageStub.resetHistory();
-        // Restore console stubs so each test starts clean.
         sinon.restore();
     });
 
-    // Run the same command-wrapper test for all 3 return codes from addUserSelectedPath():
+    // Run the same wrapper test for all 3 return codes from addUserSelectedPath():
     //   0 = added successfully
     //   1 = project already exists
     //   2 = not a Maven or Gradle project
@@ -82,42 +35,23 @@ describe("addProjectsToTheDashBoard", () => {
         { result: 2, expectedMessage: "add.project.manually.message.2:/my/project" }
     ].forEach(({ result, expectedMessage }) => {
         it(`shows the expected message and refreshes the dashboard when addUserSelectedPath returns ${result}`, async () => {
-            // Pretend the lower-level worker method already finished and returned this result.
-            // This keeps the test focused on the command wrapper behavior only.
             const addUserSelectedPathStub = sinon.stub().resolves(result);
-
-            // addProjectsToTheDashBoard() passes projectProvider.getProjects() into addUserSelectedPath().
-            // Return an empty map because the command wrapper does not care about its contents here.
             const getProjectsStub = sinon.stub().returns(new Map());
-
-            // The command should tell the dashboard tree to refresh after it handles the result.
             const fireChangeEventStub = sinon.stub();
-
-            // The command logs success with console.info() and non-success with console.error().
             const consoleInfoStub = sinon.stub(console, "info");
             const consoleErrorStub = sinon.stub(console, "error");
 
-            // Fake ProjectProvider with only the methods addProjectsToTheDashBoard() actually calls.
             const projectProvider = {
                 addUserSelectedPath: addUserSelectedPathStub,
                 getProjects: getProjectsStub,
                 fireChangeEvent: fireChangeEventStub
             } as any;
 
-            // Call the real command wrapper under test.
             await addProjectsToTheDashBoard(projectProvider, "/my/project");
 
-            // ASSERT: the command should pass the selected path and live projects map
-            // into addUserSelectedPath().
             assert.equal(addUserSelectedPathStub.calledOnceWithExactly("/my/project", getProjectsStub.firstCall.returnValue), true);
-
-            // ASSERT: the dashboard should be refreshed after the add attempt.
             assert.equal(fireChangeEventStub.calledOnce, true);
-
-            // ASSERT: the user should see the message built from the result code.
             assert.equal(showInformationMessageStub.calledOnceWithExactly(expectedMessage), true);
-
-            // ASSERT: success logs to console.info(); non-success logs to console.error().
             assert.equal(result === 0 ? consoleInfoStub.calledOnceWithExactly(expectedMessage) : consoleErrorStub.calledOnceWithExactly(expectedMessage), true);
         });
     });

--- a/src/test/unit/addProjectsToTheDashBoard.test.ts
+++ b/src/test/unit/addProjectsToTheDashBoard.test.ts
@@ -1,0 +1,119 @@
+// This test runs in plain Node, not inside a real VS Code window.
+// The extension's localization helper expects this env var to exist during import.
+process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });
+
+// Intercept module loading so we can replace VS Code and localization imports
+// with tiny fakes that are easy to reason about in a unit test.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Module = require("module");
+const originalLoad = Module._load;
+
+// Fake localization helper.
+// Instead of reading translation files, return a predictable string that includes:
+//   1. the message key the command asked for
+//   2. the selected project path passed into localize()
+// Example result: "add.project.manually.message.0:/my/project"
+const localizeStub = (key: string, selection: string) => `${key}:${selection}`;
+
+// Return a tiny fake module whenever production code imports "vscode" or the i18n helper.
+// devCommands.ts imports libertyProject.ts, and that file defines classes that extend
+// vscode.TreeItem and create vscode.EventEmitter instances. So this fake must include
+// enough of the VS Code API for those imports to load successfully.
+Module._load = function(request: string, ...args: any[]) {
+    if (request === "vscode") {
+        return {
+            EventEmitter: class { event = () => {}; fire() {} },
+            TreeItemCollapsibleState: { None: 0 },
+            TreeItem: class {
+                label: string;
+                collapsibleState: number;
+                tooltip?: string;
+                constructor(label: string, collapsibleState?: number) {
+                    this.label = label;
+                    this.collapsibleState = collapsibleState ?? 0;
+                }
+            },
+            Uri: { file: (p: string) => ({ fsPath: p }) },
+            window: {
+                showInformationMessage: showInformationMessageStub,
+                setStatusBarMessage: () => ({ dispose() {} })
+            }
+        };
+    }
+    if (request.endsWith("/util/i18nUtil") || request === "../util/i18nUtil") {
+        return {
+            localize: localizeStub
+        };
+    }
+    return originalLoad.call(this, request, ...args);
+};
+
+import * as assert from "assert";
+import * as sinon from "sinon";
+
+// Keep one shared reference to the fake VS Code message API.
+// The fake vscode module below returns this same stub, so each test can inspect
+// whether addProjectsToTheDashBoard() asked VS Code to show the expected message.
+const showInformationMessageStub = sinon.stub();
+
+import { addProjectsToTheDashBoard } from "../../liberty/devCommands";
+
+describe("addProjectsToTheDashBoard", () => {
+
+    afterEach(() => {
+        // Reset call history on the shared message stub between tests.
+        showInformationMessageStub.resetHistory();
+        // Restore console stubs so each test starts clean.
+        sinon.restore();
+    });
+
+    // Run the same command-wrapper test for all 3 return codes from addUserSelectedPath():
+    //   0 = added successfully
+    //   1 = project already exists
+    //   2 = not a Maven or Gradle project
+    [
+        { result: 0, expectedMessage: "add.project.manually.message.0:/my/project" },
+        { result: 1, expectedMessage: "add.project.manually.message.1:/my/project" },
+        { result: 2, expectedMessage: "add.project.manually.message.2:/my/project" }
+    ].forEach(({ result, expectedMessage }) => {
+        it(`shows the expected message and refreshes the dashboard when addUserSelectedPath returns ${result}`, async () => {
+            // Pretend the lower-level worker method already finished and returned this result.
+            // This keeps the test focused on the command wrapper behavior only.
+            const addUserSelectedPathStub = sinon.stub().resolves(result);
+
+            // addProjectsToTheDashBoard() passes projectProvider.getProjects() into addUserSelectedPath().
+            // Return an empty map because the command wrapper does not care about its contents here.
+            const getProjectsStub = sinon.stub().returns(new Map());
+
+            // The command should tell the dashboard tree to refresh after it handles the result.
+            const fireChangeEventStub = sinon.stub();
+
+            // The command logs success with console.info() and non-success with console.error().
+            const consoleInfoStub = sinon.stub(console, "info");
+            const consoleErrorStub = sinon.stub(console, "error");
+
+            // Fake ProjectProvider with only the methods addProjectsToTheDashBoard() actually calls.
+            const projectProvider = {
+                addUserSelectedPath: addUserSelectedPathStub,
+                getProjects: getProjectsStub,
+                fireChangeEvent: fireChangeEventStub
+            } as any;
+
+            // Call the real command wrapper under test.
+            await addProjectsToTheDashBoard(projectProvider, "/my/project");
+
+            // ASSERT: the command should pass the selected path and live projects map
+            // into addUserSelectedPath().
+            assert.equal(addUserSelectedPathStub.calledOnceWithExactly("/my/project", getProjectsStub.firstCall.returnValue), true);
+
+            // ASSERT: the dashboard should be refreshed after the add attempt.
+            assert.equal(fireChangeEventStub.calledOnce, true);
+
+            // ASSERT: the user should see the message built from the result code.
+            assert.equal(showInformationMessageStub.calledOnceWithExactly(expectedMessage), true);
+
+            // ASSERT: success logs to console.info(); non-success logs to console.error().
+            assert.equal(result === 0 ? consoleInfoStub.calledOnceWithExactly(expectedMessage) : consoleErrorStub.calledOnceWithExactly(expectedMessage), true);
+        });
+    });
+});

--- a/src/test/unit/addUserSelectedPath.test.ts
+++ b/src/test/unit/addUserSelectedPath.test.ts
@@ -1,0 +1,163 @@
+// This test runs in plain Node, not inside a real VS Code window.
+// Set the minimum localization config early so extension imports do not crash.
+process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });
+
+// When production code imports "vscode", return a tiny fake object instead.
+// We only provide the pieces ProjectProvider touches during this test.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Module = require("module");
+const originalLoad = Module._load;
+Module._load = function(request: string, ...args: any[]) {
+    if (request === "vscode") {
+        return {
+            // ProjectProvider creates an EventEmitter in its constructor.
+            EventEmitter: class { event = () => {}; fire() {} },
+            TreeItemCollapsibleState: { None: 0 },
+            TreeItem: class { constructor(label: string) { (this as any).label = label; } },
+            Uri: { file: (p: string) => ({ fsPath: p }) },
+            // refresh() temporarily shows a status bar message and later disposes it.
+            window: {
+                setStatusBarMessage: () => ({ dispose() {} })
+            }
+        };
+    }
+    return originalLoad.call(this, request, ...args);
+};
+
+
+import * as assert from "assert";
+import * as sinon from "sinon";
+
+import { ProjectProvider } from "../../liberty/libertyProject";
+import { DashboardData } from "../../liberty/dashboard";
+
+// Fake ExtensionContext for ProjectProvider.
+// addUserSelectedPath() reads saved dashboard data from workspaceState and saves updates back to it.
+const fakeContext: any = {
+    workspaceState: {
+        // Start with empty stored dashboard data.
+        get: () => new DashboardData([], []),
+        // Stubbed so each test can check whether a save happened.
+        update: sinon.stub()
+    },
+    globalState: {
+        get: () => undefined,
+        update: sinon.stub(),
+    }
+};
+
+describe("addUserSelectedPath", () => {
+
+    let provider: ProjectProvider;
+
+    before(() => {
+        // Create the real ProjectProvider instance that owns addUserSelectedPath().
+        provider = new ProjectProvider(fakeContext);
+    });
+
+    afterEach(() => {
+        // Reset Sinon-created stubs so one test's fake behavior does not leak into another.
+        sinon.restore();
+    });
+
+    // ─── Test 1 ───────────────────────────────────────────────────────────────
+    // Scenario: the user manually picks a Maven project that is not already in the dashboard.
+    // The add should succeed, update the live project map, and save the change.
+    it("returns 0 and adds project to map when valid pom.xml exists", async () => {
+
+        // These two stubs model the successful Maven path inside createLibertyProject().
+        // existsSyncStub() means "pretend pom.xml exists".
+        const existsSyncStub = sinon.stub().returns(true);
+        // readFileStub() means "pretend reading pom.xml returned this XML".
+        const readFileStub = sinon.stub().resolves(`<project><artifactId>my-app</artifactId></project>`);
+
+        // Replace ProjectProvider's internal createLibertyProject() helper for this test only.
+        // That keeps the test focused on addUserSelectedPath(): when project creation succeeds,
+        // does it add the project, save it, and return the success code?
+        (provider as any).createLibertyProject = async () => {
+            if (existsSyncStub()) {
+                await readFileStub();
+                // Return the smallest fake project object addUserSelectedPath() needs.
+                return {
+                    getPath: () => "/my/project/pom.xml",
+                    getLabel: () => "my-app",
+                    getContextValue: () => "libertyMavenProject"
+                };
+            }
+            // If project creation fails, the real helper would return undefined.
+            return undefined;
+        };
+
+        // This map represents the live set of projects currently shown in the Liberty dashboard.
+        // Start empty to model "project was not already in the dashboard".
+        const existingProjects = new Map();
+
+        // Call the real method under test.
+        const result = await provider.addUserSelectedPath("/my/project", existingProjects);
+
+        // ASSERT
+        // 0 means the manual add succeeded.
+        assert.equal(result, 0);
+        // The project should now appear in the live dashboard map.
+        assert.equal(existingProjects.has("/my/project/pom.xml"), true);
+        // The dashboard update should also be persisted to workspace storage.
+        assert.equal(fakeContext.workspaceState.update.called, true);
+    });
+
+    // ─── Test 2 ───────────────────────────────────────────────────────────────
+    // Scenario: the user picks a folder that is already in the Liberty dashboard.
+    // addUserSelectedPath() should detect the duplicate and refuse to add it again.
+    it("returns 1 and adds nothing when project already exists", async () => {
+
+        // Clear any save calls left over from earlier tests.
+        fakeContext.workspaceState.update.resetHistory();
+
+        // provider.getProjects() is the provider's internal "already in the dashboard" map.
+        // Put this path in the map first to simulate a project that Liberty Tools already knows about.
+        const dashboardProjects = provider.getProjects();
+        dashboardProjects.set("/my/project/pom.xml", {} as any);
+
+        // This separate map is the live map passed into addUserSelectedPath().
+        // It starts empty because this test is checking that nothing new gets added.
+        const existingProjects = new Map();
+
+        // Try to manually add the same project again.
+        const result = await provider.addUserSelectedPath("/my/project", existingProjects);
+
+        // ASSERT
+        // 1 means "project already exists".
+        assert.equal(result, 1);
+
+        // Because the project was a duplicate, addUserSelectedPath() should not add anything new.
+        assert.equal(existingProjects.size, 0);
+
+        // Because nothing changed, it should not save anything to workspace storage.
+        assert.equal(fakeContext.workspaceState.update.called, false);
+
+        // Clean up the provider's internal dashboard map so other tests stay isolated.
+        dashboardProjects.clear();
+    });
+
+    // ─── Test 3 ───────────────────────────────────────────────────────────────
+    // Scenario: the user picks a folder that is not a Maven or Gradle project.
+    // The add should fail without changing dashboard state.
+    it("returns 2 and adds nothing when no build file exists", async () => {
+
+        // Clear any save calls recorded by earlier tests.
+        fakeContext.workspaceState.update.resetHistory();
+        // Force project creation to fail to model a folder with no pom.xml or build.gradle.
+        (provider as any).createLibertyProject = async () => undefined;
+    
+        const existingProjects = new Map();
+        const result = await provider.addUserSelectedPath("/my/project", existingProjects);
+
+        // ASSERT
+        // 2 means the selected folder is not a Maven or Gradle project.
+        assert.equal(result, 2);
+        // Nothing should be added to the live dashboard map.
+        assert.equal(existingProjects.size, 0);
+        // Nothing should be saved because the add failed.
+        assert.equal(fakeContext.workspaceState.update.called, false);
+    });
+
+});

--- a/src/test/unit/addUserSelectedPath.test.ts
+++ b/src/test/unit/addUserSelectedPath.test.ts
@@ -1,3 +1,8 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
 // This test runs in plain Node, not inside a real VS Code window.
 // Set the minimum localization config early so extension imports do not crash.
 process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });

--- a/src/test/unit/addUserSelectedPath.test.ts
+++ b/src/test/unit/addUserSelectedPath.test.ts
@@ -4,50 +4,26 @@
  */
 
 // This test runs in plain Node, not inside a real VS Code window.
-// Set the minimum localization config early so extension imports do not crash.
-process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });
-
-// When production code imports "vscode", return a tiny fake object instead.
-// We only provide the pieces ProjectProvider touches during this test.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Module = require("module");
-const originalLoad = Module._load;
-Module._load = function(request: string, ...args: any[]) {
-    if (request === "vscode") {
-        return {
-            // ProjectProvider creates an EventEmitter in its constructor.
-            EventEmitter: class { event = () => {}; fire() {} },
-            TreeItemCollapsibleState: { None: 0 },
-            TreeItem: class { constructor(label: string) { (this as any).label = label; } },
-            Uri: { file: (p: string) => ({ fsPath: p }) },
-            // refresh() temporarily shows a status bar message and later disposes it.
-            window: {
-                setStatusBarMessage: () => ({ dispose() {} })
-            }
-        };
-    }
-    return originalLoad.call(this, request, ...args);
-};
-
-
-import * as assert from "assert";
+import { installFakeVscode } from "./fakeVscode";
 import * as sinon from "sinon";
 
+// Install the shared vscode fake — must happen before any extension imports.
+installFakeVscode();
+
+import * as assert from "assert";
 import { ProjectProvider } from "../../liberty/libertyProject";
 import { DashboardData } from "../../liberty/dashboard";
 
 // Fake ExtensionContext for ProjectProvider.
-// addUserSelectedPath() reads saved dashboard data from workspaceState and saves updates back to it.
+// addUserSelectedPath() reads saved dashboard data from workspaceState and saves updates back.
 const fakeContext: any = {
     workspaceState: {
-        // Start with empty stored dashboard data.
         get: () => new DashboardData([], []),
-        // Stubbed so each test can check whether a save happened.
         update: sinon.stub()
     },
     globalState: {
         get: () => undefined,
-        update: sinon.stub(),
+        update: sinon.stub()
     }
 };
 
@@ -56,112 +32,59 @@ describe("addUserSelectedPath", () => {
     let provider: ProjectProvider;
 
     before(() => {
-        // Create the real ProjectProvider instance that owns addUserSelectedPath().
         provider = new ProjectProvider(fakeContext);
     });
 
     afterEach(() => {
-        // Reset Sinon-created stubs so one test's fake behavior does not leak into another.
         sinon.restore();
     });
 
     // ─── Test 1 ───────────────────────────────────────────────────────────────
-    // Scenario: the user manually picks a Maven project that is not already in the dashboard.
-    // The add should succeed, update the live project map, and save the change.
+    // Scenario: the user manually picks a Maven project not already in the dashboard.
     it("returns 0 and adds project to map when valid pom.xml exists", async () => {
+        (provider as any).createLibertyProject = async () => ({
+            getPath: () => "/my/project/pom.xml",
+            getLabel: () => "my-app",
+            getContextValue: () => "libertyMavenProject"
+        });
 
-        // These two stubs model the successful Maven path inside createLibertyProject().
-        // existsSyncStub() means "pretend pom.xml exists".
-        const existsSyncStub = sinon.stub().returns(true);
-        // readFileStub() means "pretend reading pom.xml returned this XML".
-        const readFileStub = sinon.stub().resolves(`<project><artifactId>my-app</artifactId></project>`);
-
-        // Replace ProjectProvider's internal createLibertyProject() helper for this test only.
-        // That keeps the test focused on addUserSelectedPath(): when project creation succeeds,
-        // does it add the project, save it, and return the success code?
-        (provider as any).createLibertyProject = async () => {
-            if (existsSyncStub()) {
-                await readFileStub();
-                // Return the smallest fake project object addUserSelectedPath() needs.
-                return {
-                    getPath: () => "/my/project/pom.xml",
-                    getLabel: () => "my-app",
-                    getContextValue: () => "libertyMavenProject"
-                };
-            }
-            // If project creation fails, the real helper would return undefined.
-            return undefined;
-        };
-
-        // This map represents the live set of projects currently shown in the Liberty dashboard.
-        // Start empty to model "project was not already in the dashboard".
         const existingProjects = new Map();
-
-        // Call the real method under test.
         const result = await provider.addUserSelectedPath("/my/project", existingProjects);
 
-        // ASSERT
-        // 0 means the manual add succeeded.
         assert.equal(result, 0);
-        // The project should now appear in the live dashboard map.
         assert.equal(existingProjects.has("/my/project/pom.xml"), true);
-        // The dashboard update should also be persisted to workspace storage.
         assert.equal(fakeContext.workspaceState.update.called, true);
     });
 
     // ─── Test 2 ───────────────────────────────────────────────────────────────
     // Scenario: the user picks a folder that is already in the Liberty dashboard.
-    // addUserSelectedPath() should detect the duplicate and refuse to add it again.
     it("returns 1 and adds nothing when project already exists", async () => {
-
-        // Clear any save calls left over from earlier tests.
         fakeContext.workspaceState.update.resetHistory();
 
-        // provider.getProjects() is the provider's internal "already in the dashboard" map.
-        // Put this path in the map first to simulate a project that Liberty Tools already knows about.
         const dashboardProjects = provider.getProjects();
         dashboardProjects.set("/my/project/pom.xml", {} as any);
 
-        // This separate map is the live map passed into addUserSelectedPath().
-        // It starts empty because this test is checking that nothing new gets added.
         const existingProjects = new Map();
-
-        // Try to manually add the same project again.
         const result = await provider.addUserSelectedPath("/my/project", existingProjects);
 
-        // ASSERT
-        // 1 means "project already exists".
         assert.equal(result, 1);
-
-        // Because the project was a duplicate, addUserSelectedPath() should not add anything new.
         assert.equal(existingProjects.size, 0);
-
-        // Because nothing changed, it should not save anything to workspace storage.
         assert.equal(fakeContext.workspaceState.update.called, false);
 
-        // Clean up the provider's internal dashboard map so other tests stay isolated.
         dashboardProjects.clear();
     });
 
     // ─── Test 3 ───────────────────────────────────────────────────────────────
-    // Scenario: the user picks a folder that is not a Maven or Gradle project.
-    // The add should fail without changing dashboard state.
+    // Scenario: the user picks a folder with no pom.xml or build.gradle.
     it("returns 2 and adds nothing when no build file exists", async () => {
-
-        // Clear any save calls recorded by earlier tests.
         fakeContext.workspaceState.update.resetHistory();
-        // Force project creation to fail to model a folder with no pom.xml or build.gradle.
         (provider as any).createLibertyProject = async () => undefined;
-    
+
         const existingProjects = new Map();
         const result = await provider.addUserSelectedPath("/my/project", existingProjects);
 
-        // ASSERT
-        // 2 means the selected folder is not a Maven or Gradle project.
         assert.equal(result, 2);
-        // Nothing should be added to the live dashboard map.
         assert.equal(existingProjects.size, 0);
-        // Nothing should be saved because the add failed.
         assert.equal(fakeContext.workspaceState.update.called, false);
     });
 

--- a/src/test/unit/fakeVscode.ts
+++ b/src/test/unit/fakeVscode.ts
@@ -1,0 +1,74 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+/**
+ * Shared VS Code API fake for unit tests that run in plain Node (no VS Code window).
+ *
+ * Import this file before any extension code. It sets the NLS config env var,
+ * installs Module._load hooks for "vscode" and the i18n helper, and returns
+ * a mutable fake object tests can inspect and mutate.
+ */
+
+// The extension's localization helper reads this env var on import.
+// Set it before any extension module loads.
+process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: "en" });
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Module = require("module");
+const originalLoad = Module._load;
+
+export interface FakeVscode {
+    EventEmitter: any;
+    TreeItemCollapsibleState: { None: number };
+    TreeItem: any;
+    Uri: { file: (p: string) => { fsPath: string } };
+    window: {
+        showInformationMessage: (...args: any[]) => any;
+        setStatusBarMessage: () => { dispose(): void };
+    };
+    workspace: {
+        workspaceFolders: any;
+        name: any;
+    };
+}
+
+export function installFakeVscode(windowOverrides: Partial<FakeVscode["window"]> = {}): FakeVscode {
+    const fakeVscode: FakeVscode = {
+        EventEmitter: class { event = () => {}; fire() {} },
+        TreeItemCollapsibleState: { None: 0 },
+        TreeItem: class {
+            label: string;
+            collapsibleState: number;
+            constructor(label: string, collapsibleState = 0) {
+                this.label = label;
+                this.collapsibleState = collapsibleState;
+            }
+        },
+        Uri: { file: (p: string) => ({ fsPath: p }) },
+        window: {
+            showInformationMessage: () => {},
+            setStatusBarMessage: () => ({ dispose() {} }),
+            ...windowOverrides
+        },
+        workspace: {
+            workspaceFolders: undefined,
+            name: undefined
+        }
+    };
+
+    Module._load = function(request: string, ...args: any[]) {
+        if (request === "vscode") {
+            return fakeVscode;
+        }
+        // Stub the i18n helper so tests get a predictable "<key>:<arg>" string
+        // instead of crashing when NLS translation files are not available in plain Node.
+        if (request.endsWith("/util/i18nUtil") || request === "../util/i18nUtil") {
+            return { localize: (key: string, ...args2: any[]) => [key, ...args2].join(":") };
+        }
+        return originalLoad.call(this, request, ...args);
+    };
+
+    return fakeVscode;
+}

--- a/src/test/unit/fakeVscode.ts
+++ b/src/test/unit/fakeVscode.ts
@@ -31,10 +31,40 @@ export interface FakeVscode {
     workspace: {
         workspaceFolders: any;
         name: any;
+        workspaceFile: any;
     };
 }
 
-export function installFakeVscode(windowOverrides: Partial<FakeVscode["window"]> = {}): FakeVscode {
+// Paths that must be evicted from Node's require cache so that re-importing
+// libertyProject (or anything that transitively imports it) picks up the new
+// fake instead of a version bound to a previously-installed fake.
+const EXTENSION_CACHE_KEYS = [
+    "liberty/libertyProject",
+    "liberty/dashboard",
+    "liberty/baseLibertyProject",
+    "util/helperUtil",
+    "util/gradleUtil",
+    "util/mavenUtil",
+    "util/buildFile",
+    "util/i18nUtil",
+    "definitions/constants",
+];
+
+/**
+ * @param windowOverrides  Optional overrides for window methods (e.g. a sinon stub).
+ * @param clearCache       Pass true to evict all cached extension modules before
+ *                         installing the fake. Required when another test file may
+ *                         have already loaded these modules against a different fake.
+ *                         Defaults to false so existing callers are unaffected.
+ */
+export function installFakeVscode(windowOverrides: Partial<FakeVscode["window"]> = {}, clearCache = false): FakeVscode {
+    if (clearCache) {
+        Object.keys(require.cache).forEach(key => {
+            if (EXTENSION_CACHE_KEYS.some(segment => key.includes(segment))) {
+                delete require.cache[key];
+            }
+        });
+    }
     const fakeVscode: FakeVscode = {
         EventEmitter: class { event = () => {}; fire() {} },
         TreeItemCollapsibleState: { None: 0 },
@@ -54,7 +84,8 @@ export function installFakeVscode(windowOverrides: Partial<FakeVscode["window"]>
         },
         workspace: {
             workspaceFolders: undefined,
-            name: undefined
+            name: undefined,
+            workspaceFile: undefined
         }
     };
 

--- a/src/test/unit/isMultiProjectUntitledWorkspace.test.ts
+++ b/src/test/unit/isMultiProjectUntitledWorkspace.test.ts
@@ -1,0 +1,95 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
+// This test runs in plain Node, not inside a real VS Code window.
+import { installFakeVscode, FakeVscode } from "./fakeVscode";
+
+// Install the fake and clear any previously cached extension modules so this
+// file's import of libertyProject binds to our fake, regardless of test order.
+const fakeVscode: FakeVscode = installFakeVscode({}, true);
+
+import * as assert from "assert";
+import { ProjectProvider } from "../../liberty/libertyProject";
+
+// Minimal fake ExtensionContext — ProjectProvider needs one to construct.
+const fakeContext: any = {
+    workspaceState: {
+        get: () => undefined,
+        update: () => Promise.resolve()
+    },
+    globalState: {
+        get: () => undefined,
+        update: () => Promise.resolve()
+    }
+};
+
+// Helper: build a fake workspaceFolders array with n entries.
+function makeFolders(n: number) {
+    return Array.from({ length: n }, (_, i) => ({ uri: { fsPath: `/project${i}` } }));
+}
+
+describe("isMultiProjectUntitledWorkspace", () => {
+
+    let provider: ProjectProvider;
+
+    before(() => {
+        provider = new ProjectProvider(fakeContext);
+    });
+
+    // resets fake back to clean slate so test behavior is not affected by last test
+    afterEach(() => {
+        fakeVscode.workspace.workspaceFolders = undefined;
+        fakeVscode.workspace.name = undefined;
+        fakeVscode.workspace.workspaceFile = undefined;
+    });
+
+    // ─── Test 1 ───────────────────────────────────────────────────────────────
+    // Plain single-folder window (the video scenario) where workspace.name is the
+    // folder name (like gradleappadd) and no workspaceFile is saved. workspaceState
+    // is lost when user does "Save Workspace As..." so isMultiProjectUntitledWorkspace()
+    // must return true to trigger the globalState update and prevent the project from being lost.
+    it("returns true for a plain single-folder window (no .code-workspace file)", () => {
+        fakeVscode.workspace.workspaceFolders = makeFolders(1);
+        fakeVscode.workspace.name = "gradleappadd";
+        fakeVscode.workspace.workspaceFile = undefined;
+
+        assert.strictEqual(provider.isMultiProjectUntitledWorkspace(), true,
+            "A plain single-folder window loses workspaceState on Save Workspace As " +
+            "so the safe-path must trigger.");
+    });
+
+    // ─── Test 2 ───────────────────────────────────────────────────────────────
+    // VS Code auto-created "Untitled (Workspace)" (multiple folders not yet saved):
+    // workspaceFile is undefined here too, so must return true.
+    it("returns true for an auto-created untitled workspace (multiple folders)", () => {
+        fakeVscode.workspace.workspaceFolders = makeFolders(2);
+        fakeVscode.workspace.name = "Untitled (Workspace)";
+        fakeVscode.workspace.workspaceFile = undefined;
+
+        assert.strictEqual(provider.isMultiProjectUntitledWorkspace(), true);
+    });
+
+    // ─── Test 3 ───────────────────────────────────────────────────────────────
+    // Workspace already saved to a .code-workspace file: workspaceState is
+    // stable, no prompt needed.
+    it("returns false when workspace is already saved to a .code-workspace file", () => {
+        fakeVscode.workspace.workspaceFolders = makeFolders(1);
+        fakeVscode.workspace.name = "testIssue";
+        fakeVscode.workspace.workspaceFile = { fsPath: "/home/user/testIssue.code-workspace" };
+
+        assert.strictEqual(provider.isMultiProjectUntitledWorkspace(), false);
+    });
+
+    // ─── Test 4 ───────────────────────────────────────────────────────────────
+    // No folders open at all: nothing to protect, should return false.
+    it("returns false when there are no folders open", () => {
+        fakeVscode.workspace.workspaceFolders = undefined;
+        fakeVscode.workspace.name = undefined;
+        fakeVscode.workspace.workspaceFile = undefined;
+
+        assert.strictEqual(provider.isMultiProjectUntitledWorkspace(), false);
+    });
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"lib": [
 			"es6"
 		],
+		"types": ["mocha", "node"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true   /* enable all strict type-checking options */


### PR DESCRIPTION
We had to comment out all rest snippet tests for both maven and cradle because they were causing failures due to an lsp4j issue. The snapshot has just been updated with versions removed in MANIFEST.MF for lsp4j, as well as fixes for a null pointer error. This PR adds these tests back/uncomments them so we can see if the tests will pass! 