### PR TITLE
Add incompatibility warning for redhat.java >= 1.55.0

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,11 +303,29 @@ async function getJavaExtensionAPI(): Promise<JavaExtensionAPI> {
     if (!vscodeJava) {
         throw new Error("VSCode java is not installed");
     }
+    const javaVersion: string = (vscodeJava.packageJSON as Record<string, unknown>).version as string ?? "";
+    if (javaVersion && isJavaVersionIncompatible(javaVersion)) {
+        window.showWarningMessage(
+            localize("redhat.java.version.incompatible", javaVersion),
+            localize("redhat.java.version.incompatible.open"),
+            localize("redhat.java.version.incompatible.dismiss")
+        ).then(selection => {
+            if (selection === localize("redhat.java.version.incompatible.open")) {
+                commands.executeCommand("extension.open", JAVA_EXTENSION_ID);
+            }
+        });
+    }
     const api = await vscodeJava.activate();
     if (!api) {
         throw new Error("VSCode java api not found");
     }
     return Promise.resolve(api);
+}
+
+function isJavaVersionIncompatible(version: string): boolean {
+    const parts = version.split(".").map(p => parseInt(p, 10));
+    const [major = 0, minor = 0] = parts;
+    return major > 1 || (major === 1 && minor >= 55);
 }
 
 async function handleWorkspaceSaveInProgress(context: vscode.ExtensionContext): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import path = require('path');
 import * as fs from "fs";
 
 const JAVA_EXTENSION_ID = "redhat.java";
+const SUPPORTED_JAVA_VERSION = "1.54.0";
 
 const LIBERTY_CLIENT_ID = "LANGUAGE_ID_LIBERTY";
 const JAKARTA_CLIENT_ID = "LANGUAGE_ID_JAKARTA";
@@ -304,28 +305,30 @@ async function getJavaExtensionAPI(): Promise<JavaExtensionAPI> {
         throw new Error("VSCode java is not installed");
     }
     const javaVersion: string = (vscodeJava.packageJSON as Record<string, unknown>).version as string ?? "";
-    if (javaVersion && isJavaVersionIncompatible(javaVersion)) {
-        window.showWarningMessage(
-            localize("redhat.java.version.incompatible", javaVersion),
-            localize("redhat.java.version.incompatible.open"),
-            localize("redhat.java.version.incompatible.dismiss")
-        ).then(selection => {
-            if (selection === localize("redhat.java.version.incompatible.open")) {
-                commands.executeCommand("extension.open", JAVA_EXTENSION_ID);
-            }
-        });
+    if (javaVersion) {
+        const [supportedMajor, supportedMinor] = SUPPORTED_JAVA_VERSION.split(".").map(p => parseInt(p, 10));
+        const [major, minor] = javaVersion.split(".").map(p => parseInt(p, 10));
+        const isIncompatible = major > supportedMajor || (major === supportedMajor && minor > supportedMinor);
+        if (isIncompatible) {
+            window.showWarningMessage(
+                localize("redhat.java.version.incompatible", javaVersion, SUPPORTED_JAVA_VERSION),
+                localize("redhat.java.version.incompatible.install"),
+                localize("redhat.java.version.incompatible.open")
+            ).then(selection => {
+                if (selection === localize("redhat.java.version.incompatible.install")) {
+                    commands.executeCommand("workbench.extensions.installExtension", `${JAVA_EXTENSION_ID}@${SUPPORTED_JAVA_VERSION}`);
+                    commands.executeCommand("extension.open", JAVA_EXTENSION_ID);
+                } else if (selection === localize("redhat.java.version.incompatible.open")) {
+                    commands.executeCommand("extension.open", JAVA_EXTENSION_ID);
+                }
+            });
+        }
     }
     const api = await vscodeJava.activate();
     if (!api) {
         throw new Error("VSCode java api not found");
     }
     return Promise.resolve(api);
-}
-
-function isJavaVersionIncompatible(version: string): boolean {
-    const parts = version.split(".").map(p => parseInt(p, 10));
-    const [major = 0, minor = 0] = parts;
-    return major > 1 || (major === 1 && minor >= 55);
 }
 
 async function handleWorkspaceSaveInProgress(context: vscode.ExtensionContext): Promise<boolean> {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,5 +72,8 @@
     "hotkey.commands.title.add.project": "Liberty: Add Project to Liberty Tools",
     "hotkey.commands.title.remove.project": "Liberty: Remove Project from Liberty Tools",
     "hotkey.commands.title.show.commands": "Liberty: Show Liberty commands",
-    "workspace.not.saved.projects.may.not.persist": "Save the workspace first. Projects that you manually add to Liberty Tools might not persist in the next VS Code session if you don't save the workspace before you add the project."
+    "workspace.not.saved.projects.may.not.persist": "Save the workspace first. Projects that you manually add to Liberty Tools might not persist in the next VS Code session if you don't save the workspace before you add the project.",
+    "redhat.java.version.incompatible": "Liberty Tools: The installed 'Language Support for Java' extension (v{0}) is not compatible with this version of Liberty Tools. Jakarta EE diagnostics and quick-fixes will not work correctly. Downgrade 'Language Support for Java' to v1.54.0.",
+    "redhat.java.version.incompatible.open": "View in Marketplace",
+    "redhat.java.version.incompatible.dismiss": "Dismiss"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,7 +73,7 @@
     "hotkey.commands.title.remove.project": "Liberty: Remove Project from Liberty Tools",
     "hotkey.commands.title.show.commands": "Liberty: Show Liberty commands",
     "workspace.not.saved.projects.may.not.persist": "Save the workspace first. Projects that you manually add to Liberty Tools might not persist in the next VS Code session if you don't save the workspace before you add the project.",
-    "redhat.java.version.incompatible": "Liberty Tools: The installed 'Language Support for Java' extension (v{0}) is not compatible with this version of Liberty Tools. Jakarta EE diagnostics and quick-fixes will not work correctly. Downgrade 'Language Support for Java' to v1.54.0.",
-    "redhat.java.version.incompatible.open": "View in Marketplace",
-    "redhat.java.version.incompatible.dismiss": "Dismiss"
+    "redhat.java.version.incompatible": "The installed 'Language Support for Java' extension v{0} is not compatible with this version of Liberty Tools. Use 'Language Support for Java' v{1} or earlier for full support.",
+    "redhat.java.version.incompatible.install": "Install Required Version",
+    "redhat.java.version.incompatible.open": "View in Marketplace"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,6 +74,6 @@
     "hotkey.commands.title.show.commands": "Liberty: Show Liberty commands",
     "workspace.not.saved.projects.may.not.persist": "Save the workspace first. Projects that you manually add to Liberty Tools might not persist in the next VS Code session if you don't save the workspace before you add the project.",
     "redhat.java.version.incompatible": "The installed 'Language Support for Java' extension v{0} is not compatible with this version of Liberty Tools. Use 'Language Support for Java' v{1} or earlier for full support.",
-    "redhat.java.version.incompatible.install": "Install Required Version",
+    "redhat.java.version.incompatible.install": "Install Supported Version",
     "redhat.java.version.incompatible.open": "View in Marketplace"
 }

--- a/src/test/resources/ci/scripts/exec.sh
+++ b/src/test/resources/ci/scripts/exec.sh
@@ -23,6 +23,9 @@ VSCODE_VERSION_TO_RUN=$2
 #Build tool to test (maven or gradle)
 BUILD_TOOL=${3:-gradle}
 
+# Pinned version of redhat.java that is compatible with Liberty Tools (lsp4jakarta)
+REDHAT_JAVA_VERSION="1.54.0"
+
 # Current time.
 currentTime=(date +"%Y/%m/%d-%H:%M:%S:%3N")
 
@@ -51,6 +54,7 @@ main() {
 
         #Initialisation step
         npm run test-compile
+        installPinnedRedhatJava
         
         # Initialize Maven project if needed
         if [ "$BUILD_TOOL" = "maven" ]; then
@@ -114,6 +118,16 @@ main() {
 
         exit -1
     fi
+}
+
+# Download and install a pinned version of redhat.java from Open VSX to avoid
+# pulling 1.55.0+ which is incompatible with lsp4jakarta used by Liberty Tools.
+installPinnedRedhatJava() {
+    local vsix_url="https://open-vsx.org/api/redhat/java/${REDHAT_JAVA_VERSION}/file/redhat.java-${REDHAT_JAVA_VERSION}.vsix"
+    local vsix_file="/tmp/redhat.java-${REDHAT_JAVA_VERSION}.vsix"
+    echo "> $(${currentTime[@]}): Installing pinned redhat.java v${REDHAT_JAVA_VERSION} from Open VSX"
+    curl -fL "$vsix_url" -o "$vsix_file"
+    npx extest install-vsix "$vsix_file"
 }
 
 #start docker and display

--- a/src/util/javaServerStarter.ts
+++ b/src/util/javaServerStarter.ts
@@ -24,8 +24,8 @@ import * as glob from 'glob';
 import {JAKARTA_LS_JAR, LIBERTY_LS_JAR} from '../extension'
 
 const DEBUG = startedInDebugMode();
-const LIBERTY_LS_DEBUG_PORT = 8002;
-const JAKARTA_LS_DEBUG_PORT = 8003;
+const LIBERTY_LS_DEBUG_PORT = 0;
+const JAKARTA_LS_DEBUG_PORT = 0;
 
 // Referenced:
 // https://github.com/redhat-developer/vscode-microprofile/blob/master/src/languageServer/javaServerStarter.ts


### PR DESCRIPTION

Fixes: #624 

## Description:

Adds a warning popup on activation when redhat.java >= 1.55.0 is detected, since lsp4jakarta is incompatible with the breaking lsp4j API change introduced in that version.

## Changes:

1. src/extension.ts: If the version is >= 1.55.0, shows a warning message with a "View in Marketplace" button that opens the redhat.java extension page, and a "Dismiss" button. Added isJavaVersionIncompatible() helper that does a major/minor version comparison.

2. src/locales/en.json: Added three strings for the warning popup: the message text, and the two button labels.

3. src/test/resources/ci/scripts/exec.sh : Added REDHAT_JAVA_VERSION="1.54.0" constant and installPinnedRedhatJava() function that downloads the pinned VSIX so CI does not pick up an incompatible version.

4. src/util/javaServerStarter.ts: Changed hardcoded Liberty LS and Jakarta LS JDWP debug ports (8002/8003) to 0 so the OS assigns free ports. This prevents port collisions when running the Extension Development Host alongside an already running instance of Liberty Tools as I was trying to have the popup working in both Bob and vs code

Note: This check should be removed once lsp4jakarta supports lsp4j 1.x