### PR TITLE
Update LSP4Jakarta versions to 0.2.6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,9 +23,9 @@ const libertyVersion = "2.4.1";
 const jakartaGroupId = "org.eclipse.lsp4jakarta";
 const jakartaJdtArtifactId = "org.eclipse.lsp4jakarta.jdt.core";
 const jakartaLSArtifactId = "org.eclipse.lsp4jakarta.ls";
-const jakartaVersion = "0.2.6-SNAPSHOT";
+const jakartaVersion = "0.2.6";
 var lclsReleaseLevel = "releases";  //snapshots or releases
-var jakartaReleaseLevel = "snapshots";
+var jakartaReleaseLevel = "releases";
 
 const libertyLemminxName = "liberty-langserver-lemminx-" + libertyVersion + "-jar-with-dependencies.jar";
 const libertyLemminxDir = "../liberty-language-server/lemminx-liberty";

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 	],
 	"contributes": {
 		"javaExtensions": [
-			"./jars/org.eclipse.lsp4jakarta.jdt.core-0.2.6-SNAPSHOT.jar"
+			"./jars/org.eclipse.lsp4jakarta.jdt.core-0.2.6.jar"
 		],
 		"xml.javaExtensions": [
 			"./jars/liberty-langserver-lemminx-2.4.1-jar-with-dependencies.jar"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ const JAVA_EXTENSION_ID = "redhat.java";
 const LIBERTY_CLIENT_ID = "LANGUAGE_ID_LIBERTY";
 const JAKARTA_CLIENT_ID = "LANGUAGE_ID_JAKARTA";
 export const LIBERTY_LS_JAR = "liberty-langserver-2.4.1-jar-with-dependencies.jar";
-export const JAKARTA_LS_JAR = "org.eclipse.lsp4jakarta.ls-0.2.6-SNAPSHOT-jar-with-dependencies.jar";
+export const JAKARTA_LS_JAR = "org.eclipse.lsp4jakarta.ls-0.2.6-jar-with-dependencies.jar";
 
 let libertyClient: LanguageClient;
 let jakartaClient: LanguageClient;


### PR DESCRIPTION
Updates LSP4Jakarta dependency from 0.2.6-SNAPSHOT to the 0.2.6 release by changing the version and release level in gulpfile.js, the JAR filename in extension.ts, and the javaExtensions path in package.json. Resolves #626