### PR TITLE
Created Dashboard Refresh Test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "liberty-dev-vscode-ext",
-	"version": "26.0.4-SNAPSHOT",
+	"version": "26.0.7-SNAPSHOT",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "liberty-dev-vscode-ext",
-			"version": "26.0.4-SNAPSHOT",
+			"version": "26.0.7-SNAPSHOT",
 			"license": "EPL-2.0",
 			"dependencies": {
 				"@types/fs-extra": "8.1.0",

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -1,3 +1,8 @@
+/*
+ * IBM Confidential
+ * Copyright IBM Corp. 2026
+ */
+
 import { VSBrowser, DefaultTreeItem, Workbench, InputBox, Notification } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import { logger } from './utils/testLogger';

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -1,0 +1,410 @@
+import { VSBrowser, DefaultTreeItem, Workbench, InputBox, Notification, ModalDialog, EditorView } from 'vscode-extension-tester';
+import * as utils from './utils/testUtils';
+import { logger } from './utils/testLogger';
+import * as path from 'path';
+import { DashboardPage } from './pages/DashboardPage';
+import { expect } from 'chai';
+import * as constants from './definitions/constants';
+const { execSync } = require('child_process');
+
+describe("Liberty Tools Dashboard Refresh", () => {
+    let dashboard!: DashboardPage;
+
+    before(async function() {
+        this.timeout(60000);
+
+        // Open workspace
+        await VSBrowser.instance.openResources(utils.getGradleProjectPath(), utils.getMvnProjectPath());
+        await VSBrowser.instance.waitForWorkbench();
+        dashboard = new DashboardPage();
+    });
+
+    afterEach(async function() {
+        // Take screenshot on failure but don't close editor
+        if (this.currentTest?.state === 'failed') {
+            await VSBrowser.instance.driver.takeScreenshot();
+            logger.error(`Test failed: ${this.currentTest.title}`);
+            return;
+        }
+
+        // Remove all unstaged changes & untracked files that test created
+        logger.info("Cleaning up projects...");
+        for (const projectPath of [utils.getGradleProjectPath(), utils.getMvnProjectPath()]) {
+            execSync("git checkout -- . && git clean -fdx", {
+                cwd: projectPath,
+                env: process.env,
+                stdio: "inherit"
+            })
+        }
+   });
+
+    /**
+     * The following after hook closes the workspace and copies screenshots.
+     * Closing the workspace ensures the next test file starts with a clean slate.
+     */
+    after(async function() {
+        this.timeout(45000);
+        await utils.closeWorkspace();
+    });
+
+    it("Liberty Language Server should initialize", async function () {
+        logger.testStart("Liberty Language Server should initialize");
+        await utils.waitForLanguageServerInit(
+            "Language Support for Liberty",
+            "Initialized Liberty Language server",
+        );
+
+        logger.testComplete("Liberty Language Server initialized successfully");
+    }).timeout(utils.seconds(60));
+
+    it("Find Liberty Tools in sidebar", async () => {
+        logger.testStart("Find Liberty Tools in sidebar");
+
+        try {
+            logger.step(1, "Attempting to get Liberty Tools section");
+            const section = await dashboard.getSection(); 
+            logger.stepSuccess(1, "Found Liberty Tools section");
+
+            logger.step(2, "Validating sidebar is not undefined");
+            expect(section).not.undefined;
+            logger.testComplete("Find Liberty Tools in sidebar");
+        } catch (error) {
+            logger.testFailed("Find Liberty Tools in sidebar", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(60));
+
+    // Test that correct tooltips are shown before any changes
+    it("Liberty Tools shows correct tooltips for projects", async () => {
+        logger.testStart("Liberty Tools shows correct tooltips for projects");
+        try {
+            const toolConfigsStandard: ToolConfig[] = [
+                {  // Maven project should have pom.xml
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml"
+                },
+                {  // Gradle project should have build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle"
+                }
+            ];
+
+            await verifyDashboardIsCorrect(1, toolConfigsStandard);
+
+            logger.testComplete("Liberty Tools shows correct tooltips for projects");
+        } catch (error) {
+            logger.testFailed("Liberty Tools shows correct tooltips for projects", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(275));
+
+    // Test that dashboard refreshes automatically when projects added to workspace
+    it("Liberty Tools shows correct tooltips after project added to workspace", async () => {
+        logger.testStart("Liberty Tools shows correct tooltips after project added to workspace");
+        try {
+            logger.step(1, "Open gradle-9 folder");
+            await utils.closeWorkspace();
+            await VSBrowser.instance.openResources(utils.getGradleProjectPath(), utils.getMvnProjectPath(), utils.getGradle9ProjectPath());
+            await VSBrowser.instance.waitForWorkbench();
+            logger.stepSuccess(1, "Opened gradle-9 folder");
+
+            const toolConfigsWithThreeProjects: ToolConfig[] = [
+                {  // Maven unchanged
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                },
+                {  // Gradle unchanged
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // newly added gradle-9 project
+                    nameOfProject: constants.GRADLE_9_PROJECT,
+                    identifyingFile: "build.gradle",
+                }
+            ];
+
+            let step = await verifyDashboardIsCorrect(2, toolConfigsWithThreeProjects);
+
+            logger.step(step, "Close gradle-9 folder and re-open just gradle & maven");
+            await utils.closeWorkspace();
+            await VSBrowser.instance.openResources(utils.getGradleProjectPath(), utils.getMvnProjectPath());
+            await VSBrowser.instance.waitForWorkbench();
+            logger.stepSuccess(step, "Closed gradle-9 folder and re-opened only gradle, maven");
+            step++;
+
+            const toolConfigsStandard: ToolConfig[] = [
+                {  // Maven unchanged
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                },
+                {  // Gradle unchanged
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                }
+            ];
+
+            await verifyDashboardIsCorrect(step, toolConfigsStandard);
+
+            logger.testComplete("Liberty Tools shows correct tooltips after project added to workspace");
+        } catch (error) {
+            logger.testFailed("Liberty Tools shows correct tooltips after project added to workspace", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(275));
+
+    // Test that dashboard refreshes when project type changes
+    it("Liberty Tools shows correct tooltips after change maven project to gradle project", async () => {
+        logger.testStart("Liberty Tools shows correct tooltips after change maven project to gradle project");
+        try {
+            logger.step(1, "Copy build.gradle to maven project");
+            execSync("cp build.gradle ../../maven/liberty-maven-test-wrapper-app/", {
+                cwd: utils.getGradleProjectPath(),
+                env: process.env,
+                stdio: "inherit"
+            });
+            logger.stepSuccess(1, "File copied");
+
+            logger.step(2, "Remove pom.xml");
+            execSync("rm pom.xml", {
+                cwd: utils.getMvnProjectPath(),
+                env: process.env,
+                stdio: "inherit"
+            });
+            logger.stepSuccess(2, "File removed");
+
+            const toolConfigsSwitched: ToolConfig[] = [
+                {  // Maven changed from pom.xml to build.gradle
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // Gradle unchanged, still build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                }
+            ];
+
+            await verifyDashboardIsCorrect(3, toolConfigsSwitched);
+
+            logger.testComplete("Liberty Tools shows correct tooltips after change maven project to gradle project");
+        } catch (error) {
+            logger.testFailed("Liberty Tools shows correct tooltips after change maven project to gradle project", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(275));
+    
+    const NEW_PROJECT_NAME = "newProject";
+    // Test that dashboard refreshes when project manually added & removed
+    it("Liberty Tools shows correct tooltips after manually adding & removing new project", async () => {
+        logger.testStart("Liberty Tools shows correct tooltips after create new project");
+        try {
+            logger.step(1, "Create new gradle project: newProject");
+            createNewGradleProject();
+            logger.stepSuccess(1, "Project created");
+
+            // Wait so liberty tools can find the new project
+            await utils.getWaitHelper().sleep(utils.seconds(5));
+
+            logger.step(2, "Add new project to dashboard");
+            await new Workbench().executeCommand("liberty.dev.add.project");
+            const addProjectInput: InputBox = await InputBox.create();
+            await addProjectInput.confirm();
+            logger.stepSuccess(2, "Added new project");
+
+            const toolConfigsWithNewProject: ToolConfig[] = [
+                {  // Gradle unchanged, still build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // Maven not changed this test
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                },
+                {  // New project
+                    nameOfProject: NEW_PROJECT_NAME,
+                    identifyingFile: "build.gradle"
+                }
+            ];
+
+            let step = await verifyDashboardIsCorrect(3, toolConfigsWithNewProject);
+
+            logger.step(step, "Execute remove project command");
+            await new Workbench().executeCommand("liberty.dev.remove.project");
+            const removeProjectInput: InputBox = await InputBox.create();
+            await removeProjectInput.confirm();
+            logger.stepSuccess(step, "Executed remove project command");
+            step++;
+
+            logger.step(step, "Confirm removal via notification");
+            const allNotifications: Notification[] = await new Workbench().getNotifications();
+            let removeProjectNotification: Notification | undefined;
+            for (const noti of allNotifications) {
+                if ((await noti.getText()).includes("Are you sure you want to remove the project")) {
+                    removeProjectNotification = noti;
+                    break;
+                }
+            }
+            expect(removeProjectNotification).not.undefined;
+            await removeProjectNotification?.takeAction("Yes");
+            logger.stepSuccess(step, "Removed project");
+            step++;
+
+            const toolConfigsAfterNewProjectRemoval: ToolConfig[] = [
+                {  // Gradle unchanged, still build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // Maven not changed this test
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                }
+            ];
+
+            await verifyDashboardIsCorrect(step, toolConfigsAfterNewProjectRemoval);
+
+            logger.testComplete("Liberty Tools shows correct tooltips after create new project");
+        } catch (error) {
+            logger.testFailed("Liberty Tools shows correct tooltips after create new project", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(275));
+
+    // Test that dashboard refresh button works
+    it("Liberty Tools shows correct tooltips after manually adding new project then refreshing", async () => {
+        logger.testStart("Liberty Tools shows correct tooltips after manually adding new project then refreshing");
+        try {
+            logger.step(1, "Create new gradle project: newProject");
+            createNewGradleProject();
+            logger.stepSuccess(1, "Project created");
+
+            // Wait so liberty tools can find the new project
+            await utils.getWaitHelper().sleep(utils.seconds(5));
+
+            logger.step(2, "Add new project to dashboard");
+            await new Workbench().executeCommand("liberty.dev.add.project");
+            const addProjectInput: InputBox = await InputBox.create();
+            await addProjectInput.confirm();
+            logger.stepSuccess(2, "Added new project");
+
+            const toolConfigsWithNewProject: ToolConfig[] = [
+                {  // Gradle unchanged, still build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // Maven not changed this test
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                },
+                {  // New project
+                    nameOfProject: NEW_PROJECT_NAME,
+                    identifyingFile: "build.gradle"
+                }
+            ];
+
+            let step = await verifyDashboardIsCorrect(3, toolConfigsWithNewProject);
+
+            logger.step(step, "Remove newProject directory");
+            execSync("rm -rf newProject", {
+                cwd: utils.getGradleProjectPath(),
+                env: process.env,
+                stdio: "inherit"
+            });
+            logger.stepSuccess(step, "Removed directory");
+            step++;
+
+            // Confirm that even after directory removed, dashboard has not refreshed
+            step = await verifyDashboardIsCorrect(step, toolConfigsWithNewProject);
+
+            logger.step(step, "Clicking refresh projects button");
+            await dashboard.clickActionButton("Refresh projects");
+            logger.stepSuccess(step, "Projects refreshed");
+            step++;
+
+            const toolConfigsAfterRefresh: ToolConfig[] = [
+                {  // Gradle unchanged, still build.gradle
+                    nameOfProject: constants.GRADLE_PROJECT,
+                    identifyingFile: "build.gradle",
+                },
+                {  // Maven not changed this test
+                    nameOfProject: constants.MAVEN_PROJECT,
+                    identifyingFile: "pom.xml",
+                }
+            ];
+
+            await verifyDashboardIsCorrect(step, toolConfigsAfterRefresh);
+
+            logger.testComplete("Liberty Tools shows correct tooltips after manually adding new project then refreshing");
+        } catch (error) {
+            logger.testFailed("Liberty Tools shows correct tooltips after manually adding new project then refreshing", error);
+            throw error;
+        }
+    }).timeout(utils.seconds(275));
+
+    /** Creates a project called newProject containing a build.gradle file. */
+    function createNewGradleProject() {
+        execSync(`mkdir ${NEW_PROJECT_NAME} && touch ${NEW_PROJECT_NAME}/build.gradle`, {
+            cwd: utils.getGradleProjectPath(),
+            env: process.env,
+            stdio: "inherit"
+        });
+    }
+
+    /** Specifies the expected information for a project in the dashboard */
+    interface ToolConfig {
+
+        /** The name of the project displayed in the dashboard; this may also be called `projectConstant` */
+        nameOfProject: string;
+
+        /** The file used to identify whether this project is a maven project or a gradle project */
+        identifyingFile: "build.gradle" | "pom.xml";
+    }
+
+    /**
+     * Verifies that the dashboard displays the expected projects with correct tooltips.
+     * @returns The next step number after all verification steps have completed.
+     */
+    async function verifyDashboardIsCorrect(stepToStartAt: number, toolConfigs: ToolConfig[]): Promise<number> {
+        let step: number = stepToStartAt;
+
+        logger.step(step, "Getting dashboard section");
+        const section = await dashboard.getSection();
+        logger.stepSuccess(step, "Dashboard section retrieved");
+        step++;
+
+        logger.step(step, "Waiting for Liberty Tools to load");
+        await utils.waitForDashboardToLoad(section);
+        logger.stepSuccess(step, "Liberty Tools loaded successfully");
+        step++;
+
+        logger.step(step, "Getting visible items from section");
+        const menu = await utils.waitForCondition(async () => {
+            const items = await section.getVisibleItems();
+            if (items && items.length > 0) {
+                return items;
+            }
+            return;
+        }, 60);
+        logger.info(`Found ${menu.length} visible items in dashboard`);
+        expect(menu.length).to.equal(toolConfigs.length);
+        logger.stepSuccess(step, "Getting visible items from section");
+        step++;
+
+        for (const toolConfig of toolConfigs) {
+            const { nameOfProject, identifyingFile } = toolConfig;
+            const buildToolForLogs: string = (identifyingFile === "pom.xml") ? "maven" : "gradle";
+
+            logger.step(step, `Finding project item: ${nameOfProject} [${buildToolForLogs}]`);
+            const item: DefaultTreeItem = await dashboard.getProjectItem(nameOfProject);
+            expect(item).not.undefined;
+            logger.stepSuccess(step, `${nameOfProject} project item found`);
+            step++;
+
+            logger.step(step, `Check that for ${nameOfProject}, tooltip shows "${identifyingFile}"`);
+            const tooltipText: string = await item.getTooltip();
+            expect(path.basename(tooltipText)).to.equal(identifyingFile)
+            logger.stepSuccess(step, `Tooltip confirmed: ${identifyingFile}`);
+            step++;
+        }
+
+        return step;
+    }
+});

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -44,7 +44,7 @@ describe("Liberty Tools Dashboard Refresh", () => {
                 cwd: projectPath,
                 env: process.env,
                 stdio: "inherit"
-            })
+            });
         }
    });
 

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -203,6 +203,16 @@ describe("Liberty Tools Dashboard Refresh", () => {
     }).timeout(utils.seconds(275));
     
     const NEW_PROJECT_NAME = "newProject";
+
+    /** Creates a project called newProject containing a build.gradle file. */
+    function createNewGradleProject() {
+        execSync(`mkdir ${NEW_PROJECT_NAME} && touch ${NEW_PROJECT_NAME}/build.gradle`, {
+            cwd: utils.getGradleProjectPath(),
+            env: process.env,
+            stdio: "inherit"
+        });
+    }
+
     // Test that dashboard refreshes when project manually added & removed
     it("Liberty Tools shows correct tooltips after manually adding & removing new project", async () => {
         logger.testStart("Liberty Tools shows correct tooltips after create new project");
@@ -348,15 +358,6 @@ describe("Liberty Tools Dashboard Refresh", () => {
             throw error;
         }
     }).timeout(utils.seconds(275));
-
-    /** Creates a project called newProject containing a build.gradle file. */
-    function createNewGradleProject() {
-        execSync(`mkdir ${NEW_PROJECT_NAME} && touch ${NEW_PROJECT_NAME}/build.gradle`, {
-            cwd: utils.getGradleProjectPath(),
-            env: process.env,
-            stdio: "inherit"
-        });
-    }
 
     /**
      * Verifies that the dashboard displays the expected projects with correct tooltips.

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -1,4 +1,4 @@
-import { VSBrowser, DefaultTreeItem, Workbench, InputBox, Notification, ModalDialog, EditorView } from 'vscode-extension-tester';
+import { VSBrowser, DefaultTreeItem, Workbench, InputBox, Notification } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import { logger } from './utils/testLogger';
 import * as path from 'path';
@@ -6,6 +6,16 @@ import { DashboardPage } from './pages/DashboardPage';
 import { expect } from 'chai';
 import * as constants from './definitions/constants';
 const { execSync } = require('child_process');
+
+/** Specifies the expected information for a project in the dashboard */
+interface ToolConfig {
+
+    /** The name of the project displayed in the dashboard; this may also be called `projectConstant` */
+    nameOfProject: string;
+
+    /** The file used to identify whether this project is a maven project or a gradle project */
+    identifyingFile: "build.gradle" | "pom.xml";
+}
 
 describe("Liberty Tools Dashboard Refresh", () => {
     let dashboard!: DashboardPage;
@@ -346,16 +356,6 @@ describe("Liberty Tools Dashboard Refresh", () => {
             env: process.env,
             stdio: "inherit"
         });
-    }
-
-    /** Specifies the expected information for a project in the dashboard */
-    interface ToolConfig {
-
-        /** The name of the project displayed in the dashboard; this may also be called `projectConstant` */
-        nameOfProject: string;
-
-        /** The file used to identify whether this project is a maven project or a gradle project */
-        identifyingFile: "build.gradle" | "pom.xml";
     }
 
     /**

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -215,7 +215,7 @@ describe("Liberty Tools Dashboard Refresh", () => {
 
     // Test that dashboard refreshes when project manually added & removed
     it("Liberty Tools shows correct tooltips after manually adding & removing new project", async () => {
-        logger.testStart("Liberty Tools shows correct tooltips after create new project");
+        logger.testStart("Liberty Tools shows correct tooltips after manually adding & removing new project");
         try {
             logger.step(1, "Create new gradle project: newProject");
             createNewGradleProject();
@@ -281,9 +281,9 @@ describe("Liberty Tools Dashboard Refresh", () => {
 
             await verifyDashboardIsCorrect(step, toolConfigsAfterNewProjectRemoval);
 
-            logger.testComplete("Liberty Tools shows correct tooltips after create new project");
+            logger.testComplete("Liberty Tools shows correct tooltips after manually adding & removing new project");
         } catch (error) {
-            logger.testFailed("Liberty Tools shows correct tooltips after create new project", error);
+            logger.testFailed("Liberty Tools shows correct tooltips after manually adding & removing new project", error);
             throw error;
         }
     }).timeout(utils.seconds(275));

--- a/src/test/TestDashboardRefresh.ts
+++ b/src/test/TestDashboardRefresh.ts
@@ -1,8 +1,3 @@
-/*
- * IBM Confidential
- * Copyright IBM Corp. 2026
- */
-
 import { VSBrowser, DefaultTreeItem, Workbench, InputBox, Notification } from 'vscode-extension-tester';
 import * as utils from './utils/testUtils';
 import { logger } from './utils/testLogger';
@@ -172,7 +167,7 @@ describe("Liberty Tools Dashboard Refresh", () => {
         logger.testStart("Liberty Tools shows correct tooltips after change maven project to gradle project");
         try {
             logger.step(1, "Copy build.gradle to maven project");
-            execSync("cp build.gradle ../../maven/liberty-maven-test-wrapper-app/", {
+            execSync(`cp build.gradle "${utils.getMvnProjectPath()}"`, {
                 cwd: utils.getGradleProjectPath(),
                 env: process.env,
                 stdio: "inherit"

--- a/src/test/pages/DashboardPage.ts
+++ b/src/test/pages/DashboardPage.ts
@@ -3,7 +3,7 @@
  * Copyright IBM Corp. 2026
  */
 
-import { SideBarView, ViewSection, DefaultTreeItem } from 'vscode-extension-tester';
+import { SideBarView, ViewSection, DefaultTreeItem, ViewPanelAction } from 'vscode-extension-tester';
 import * as utils from '../utils/testUtils';
 
 export class DashboardPage {
@@ -35,5 +35,15 @@ export class DashboardPage {
         await utils.launchDashboardAction(item, action, macAction);
     }
 
-
+    /**
+     * Click a panel-level action button on the dashboard section (e.g. the
+     * refresh icon in the section toolbar).
+     *
+     * @param buttonLabel The accessible label of the button to click.
+     */
+    async clickActionButton(buttonLabel: string): Promise<void> {
+        const section: ViewSection = await this.getSection();
+        const action = (await section.getAction(buttonLabel)) as ViewPanelAction;
+        await action.click();
+    }
 }

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -671,6 +671,21 @@ export async function closeWorkspace(): Promise<void> {
         // Close the workspace/folder
         await workbench.executeCommand('workbench.action.closeFolder');
         await getWaitHelper().sleep(2000); // Wait for workspace to close
+
+        // Sometimes a modal pops up asking you to save workspace so bypass
+        try {
+            await getWaitHelper().forCondition(async () => {
+                try {
+                    await new ModalDialog().pushButton("Don't Save");
+                    return true;
+                }
+                catch {
+                    return;
+                }
+            }, { timeout: seconds(5) });
+        } catch {
+            // Bypass -> do nothing
+        }
         
         logger.info('Workspace closed successfully');
     } catch (error) {


### PR DESCRIPTION
## Changes

### Created `TestDashboardRefresh` test
- Checks that dashboard refreshes automatically when projects added to workspace
- Checks that dashboard refreshes when project type changes (changing maven project -> gradle project)
- Checks that dashboard refreshes when project manually added & removed
- Checks that dashboard refresh button works

### Notes
- I couldn't find a reliable way to tell when the dashboard icon changes which is why I decided to use tooltips in order to validate dashboard information
- Only added refresh testing for `pom.xml` and `build.gradle` files; `settings.gradle` and `server.xml` *do* trigger a refresh but *don't* update dashboard information so I decided to not test them.

## Related Issue
- Resolves #532 
