### PR TITLE
Move Manual Add

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,14 +108,12 @@
 			{
 				"command": "liberty.dev.add.project",
 				"category": "Liberty",
-				"title": "%commands.title.add.project%",
-				"icon": "$(add)"
+				"title": "%commands.title.add.project%"
 			},
 			{
 				"command": "liberty.dev.remove.project",
 				"category": "Liberty",
-				"title": "%commands.title.remove.project%",
-				"icon": "$(remove)"
+				"title": "%commands.title.remove.project%"
 			},
 			{
 				"command": "liberty.dev.stop",
@@ -190,18 +188,6 @@
 					"when": "false"
 				}
 			],
-			"explorer/context": [
-				{
-					"command": "liberty.dev.add.project",
-					"when": "explorerResourceIsRoot",
-					"group": "liberty"
-				},
-				{
-					"command": "liberty.dev.remove.project",
-					"when": "explorerResourceIsRoot",
-					"group": "liberty"
-				}
-			],
 			"view/title": [
 				{
 					"command": "liberty.explorer.refresh",
@@ -212,16 +198,6 @@
 					"command": "workbench.actions.treeView.liberty-dev.collapseAll",
 					"when": "view == liberty-dev",
 					"group": "navigation@2"
-				},
-				{
-					"command": "liberty.dev.add.project",
-					"when": "view == liberty-dev",
-					"group": "navigation@3"
-				},
-				{
-					"command": "liberty.dev.remove.project",
-					"when": "view == liberty-dev",
-					"group": "navigation@4"
 				},
 				{
 					"command": "liberty.explorer.sort.workspace",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,7 @@ function registerCommands(context: ExtensionContext) {
         [CMD_OPEN_FAILSAFE_REPORT, (p?: LibertyProject) => devCommands.openReport("failsafe", p)],
         [CMD_OPEN_SUREFIRE_REPORT, (p?: LibertyProject) => devCommands.openReport("surefire", p)],
         [CMD_OPEN_GRADLE_TEST_REPORT, (p?: LibertyProject) => devCommands.openReport("gradle", p)],
-        [CMD_ADD_PROJECT, (uri: vscode.Uri) => devCommands.addProject(uri)],
+        [CMD_ADD_PROJECT, () => devCommands.addProject()],
         [CMD_REMOVE_PROJECT, () => devCommands.removeProject()],
         [CMD_SORT_WORKSPACE, () => projectProvider.setSortOrder("workspace")],
         [CMD_SORT_WORKSPACE_ACTIVE, () => projectProvider.setSortOrder("workspace")],

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -206,15 +206,8 @@ export async function addProject(): Promise<void> {
     const projectProvider: ProjectTreeProvider = ProjectTreeProvider.getInstance();
     const registry = ProjectRegistry.getInstance();
 
-    // Collect all folders with pom.xml/build.gradle not already in the registry,
-    // across all workspace folders. These are projects auto-detection did not register.
-    let folderPaths: string[] = [];
-    const wsFolders = vscode.workspace.workspaceFolders;
-    if (wsFolders) {
-        for (const folder of wsFolders) {
-            folderPaths = folderPaths.concat(await registry.getListOfMavenAndGradleFolders(folder.uri.fsPath));
-        }
-    }
+    // Folders with build files rejected by auto-detection — candidates for manual add.
+    const folderPaths: string[] = registry.getUnregisteredBuildFolders();
 
     if (folderPaths.length === 0) {
         const message = localize("add.project.manually.no.projects.available.to.add");
@@ -593,7 +586,7 @@ Method adds a project which is selected by the user from the list to the liberty
 */
 export async function addProjectsToTheDashBoard(projectProvider: ProjectTreeProvider, selection: string): Promise<void> {
     const registry = ProjectRegistry.getInstance();
-    const result = await registry.addUserSelectedPath(selection, registry.getProjects());
+    const result = await registry.addUserSelectedPath(selection);
     const message = localize(`add.project.manually.message.${result}`, selection);
     (result !== 0) ? console.error(message) : console.info(message);
     vscode.window.showInformationMessage(message);

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -202,70 +202,45 @@ export async function removeProject(): Promise<void> {
     }
 }
 
-function showListOfPathsToAdd(uris: string[]) {
+export async function addProject(): Promise<void> {
     const projectProvider: ProjectTreeProvider = ProjectTreeProvider.getInstance();
-    vscode.window.showQuickPick(uris).then(async selection => {
+    const registry = ProjectRegistry.getInstance();
+
+    // Collect all folders with pom.xml/build.gradle not already in the registry,
+    // across all workspace folders. These are projects auto-detection did not register.
+    let folderPaths: string[] = [];
+    const wsFolders = vscode.workspace.workspaceFolders;
+    if (wsFolders) {
+        for (const folder of wsFolders) {
+            folderPaths = folderPaths.concat(await registry.getListOfMavenAndGradleFolders(folder.uri.fsPath));
+        }
+    }
+
+    if (folderPaths.length === 0) {
+        const message = localize("add.project.manually.no.projects.available.to.add");
+        console.error(message);
+        vscode.window.showInformationMessage(message);
+        return;
+    }
+
+    const items: LibertyProjectQuickPickItem[] = folderPaths.map(folderPath => {
+        const wsFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(folderPath));
+        const displayPath = wsFolder
+            ? Path.relative(wsFolder.uri.fsPath, folderPath)
+            : folderPath;
+        return new LibertyProjectQuickPickItem(Path.basename(folderPath), folderPath, undefined, displayPath);
+    });
+
+    vscode.window.showQuickPick(items).then(async selection => {
         if (!selection) {
             return;
         }
         if (projectProvider.isMultiProjectUntitledWorkspace()) {
-            /**
-             * Saving the selected project to globalstate for adding it to the dashboard after 
-             * reinitialization of the extension when workspace is saved
-             */
-            await ProjectRegistry.getInstance().getContext().globalState.update('selectedProject', selection);
-            /*
-            if the workspace is untitled suggest the user to save the workspace first 
-            */
+            await ProjectRegistry.getInstance().getContext().globalState.update('selectedProject', selection.detail);
             await projectProvider.checkUntitledWorkspaceAndSaveIt();
         }
-        await addProjectsToTheDashBoard(projectProvider, selection);
+        await addProjectsToTheDashBoard(projectProvider, selection.detail);
     });
-}
-
-export async function addProject(uri: vscode.Uri): Promise<void> {
-    const projectProvider: ProjectTreeProvider = ProjectTreeProvider.getInstance();
-    const registry = ProjectRegistry.getInstance();
-    if (uri !== undefined && uri !== null && uri.fsPath !== undefined) {
-        // Right mouse clicked on a root folder, or on empty space with only one folder in workspace.
-        // Add project if:
-        // 1. Not in liberty dashboard
-        // 2. Project has build files (pom.xml or build.gradle)
-        // 
-        // Once added, presist the data in workspace storage.
-        console.error("projects " + JSON.stringify(registry.getProjects()));
-        // scan the folder and get a list of folders with pom.xml and build.gradle
-        const uris: string[] = await registry.getListOfMavenAndGradleFolders(uri.fsPath);
-        console.log(JSON.stringify(uris));
-        if (uris.length > 0) {
-            // present the list to add
-            showListOfPathsToAdd(uris);
-        }
-
-
-    } else {
-        // clicked on the empty space and workspace has more than one folders, or
-        // from command palette or clicked on (+) button in Liberty dashboard
-        // Display the list of workspace folders for user to select.
-        // The list should not contain any existing projects
-        let uris: string[] = [];
-        const wsFolders = vscode.workspace.workspaceFolders;
-        if (wsFolders) {
-            for (const folder of wsFolders) {
-                const path = folder.uri.fsPath;
-                uris = uris.concat(await registry.getListOfMavenAndGradleFolders(path));
-            }
-        }
-        if (uris.length === 0) {
-            // show error
-            const message = localize("add.project.manually.no.projects.available.to.add");
-            console.error(message);
-            vscode.window.showInformationMessage(message);
-        } else {
-            // present the list
-            showListOfPathsToAdd(uris);
-        }
-    }
 }
 // stop dev mode
 export async function stopDevMode(libProject?: LibertyProject | undefined): Promise<void> {

--- a/src/liberty/projectDiscovery.ts
+++ b/src/liberty/projectDiscovery.ts
@@ -16,7 +16,6 @@ import {
 	isMaven, isGradle,
 } from "../definitions/constants";
 import { BuildFileImpl, GradleBuildFile } from "../util/buildFile";
-import { BaseLibertyProject } from "./baseLibertyProject";
 import { LibertyProject, createProject, getLabelFromBuildFile } from "./libertyProject";
 
 /**
@@ -36,6 +35,7 @@ export interface ParsedBuildEntry {
 export interface DiscoveryResult {
 	projects: Map<string, LibertyProject>;
 	rootProjects: LibertyProject[];
+	rejectedBuildFiles: string[];
 }
 
 /**
@@ -490,14 +490,12 @@ function projectRootPathExists(path: string, keys: Iterable<string>): boolean {
  * @param context         Extension context (for project creation, storage)
  * @param wsFolders       Workspace folders to scan
  * @param existingProjects Currently live projects (preserves terminal state across refreshes)
- * @param persistedProjects Projects persisted in workspace storage (manually added)
  * @param onFolderComplete Called after each folder completes — used for progressive tree updates
  */
 export async function discoverWorkspace(
 	context: vscode.ExtensionContext,
 	wsFolders: readonly vscode.WorkspaceFolder[],
 	existingProjects: Map<string, LibertyProject>,
-	persistedProjects: BaseLibertyProject[],
 	onFolderComplete?: (partial: Map<string, LibertyProject>, foldersComplete: number, totalFolders: number) => void
 ): Promise<DiscoveryResult> {
 	const t0 = Date.now();
@@ -520,15 +518,6 @@ export async function discoverWorkspace(
 		const pomPaths = pomUris.map(u => u.fsPath);
 		const gradlePaths = gradleUris.map(u => u.fsPath);
 
-		for (const p of persistedProjects) {
-			if (!p.path.startsWith(folderPath)) { continue; }
-			if (p.path.endsWith("pom.xml") && !pomPaths.includes(p.path)) {
-				pomPaths.push(p.path);
-			} else if (p.path.endsWith("build.gradle") && !gradlePaths.includes(p.path)) {
-				gradlePaths.push(p.path);
-			}
-		}
-
 		console.log(`[perf] folder ${folderPath} findFiles: ${Date.now() - t0}ms  (${pomPaths.length} pom, ${gradlePaths.length} gradle)`);
 
 		const folderMap: Map<string, LibertyProject> = new Map();
@@ -549,7 +538,8 @@ export async function discoverWorkspace(
 
 	const { mavenMetadataMap, gradleMetadataMap } = await stampProjects(newProjectsMap, allEntries);
 	const rootProjects = await linkProjects(newProjectsMap, mavenMetadataMap, gradleMetadataMap);
+	const rejectedBuildFiles = allEntries.map(e => e.path).filter(p => !newProjectsMap.has(p));
 
 	console.log(`[perf] discoverWorkspace total: ${Date.now() - t0}ms  (${newProjectsMap.size} projects, ${rootProjects.length} roots)`);
-	return { projects: newProjectsMap, rootProjects };
+	return { projects: newProjectsMap, rootProjects, rejectedBuildFiles };
 }

--- a/src/liberty/projectRegistry.ts
+++ b/src/liberty/projectRegistry.ts
@@ -26,6 +26,10 @@ export class ProjectRegistry {
 
 	private _rootProjects: LibertyProject[] = [];
 
+	private _rejectedBuildFiles: string[] = [];
+
+	private _addedProjects: Map<string, LibertyProject> = new Map();
+
 	constructor(context: vscode.ExtensionContext) {
 		this._context = context;
 	}
@@ -58,8 +62,30 @@ export class ProjectRegistry {
 		this._rootProjects = rootProjects;
 	}
 
+	public setRejectedBuildFiles(paths: string[]): void {
+		this._rejectedBuildFiles = paths;
+	}
+
+	public getUnregisteredBuildFolders(): string[] {
+		return this._rejectedBuildFiles
+			.filter(p => !this._projects.has(p) && !this._addedProjects.has(p))
+			.map(p => vscodePath.dirname(p));
+	}
+
 	public getUserAddedProjects(): BaseLibertyProject[] {
 		return util.getStorageData(this._context).projects;
+	}
+
+	public getAddedProjects(): LibertyProject[] {
+		return Array.from(this._addedProjects.values());
+	}
+
+	public addToAddedProjects(project: LibertyProject): void {
+		this._addedProjects.set(project.getPath(), project);
+	}
+
+	public removeFromAddedProjects(path: string): void {
+		this._addedProjects.delete(path);
 	}
 
 	/**
@@ -86,15 +112,16 @@ export class ProjectRegistry {
 	 * Adds a user-selected project path to the registry and persists it.
 	 * Returns: 0 = success, 1 = already exists, 2 = not a Maven/Gradle project.
 	 */
-	public async addUserSelectedPath(path: string, existingProjects: Map<string, LibertyProject>): Promise<number> {
+	public async addUserSelectedPath(path: string): Promise<number> {
 		const pomFile = vscodePath.resolve(path, "pom.xml");
 		const gradleFile = vscodePath.resolve(path, "build.gradle");
-		if (this._projects.has(pomFile) || this._projects.has(gradleFile)) {
+		if (this._projects.has(pomFile) || this._projects.has(gradleFile)
+			|| this._addedProjects.has(pomFile) || this._addedProjects.has(gradleFile)) {
 			return 1;
 		}
-		const project = await createLibertyProjectFromPath(this._context, path, undefined, existingProjects);
+		const project = await createLibertyProjectFromPath(this._context, path, undefined, this._projects);
 		if (project !== undefined) {
-			existingProjects.set(project.getPath(), project);
+			this._addedProjects.set(project.getPath(), project);
 			const baseProject = new BaseLibertyProject(project.getLabel(), project.getPath(), project.getContextValue());
 			const dashboardData: DashboardData = util.getStorageData(this._context);
 			dashboardData.addProjectToManualProjects(baseProject);
@@ -121,7 +148,7 @@ export class ProjectRegistry {
 		if (dashboard.isPathExists(path)) {
 			dashboard.removeProject(path);
 			util.saveStorageData(this._context, dashboard);
-			this._projects.delete(path);
+			this._addedProjects.delete(path);
 		}
 	}
 
@@ -140,7 +167,8 @@ export class ProjectRegistry {
 	}
 
 	/**
-	 * Load persisted (manually-added) projects into the registry.
+	 * Load persisted (manually-added) projects into _addedProjects.
+	 * Stale entries (build file no longer exists) are cleaned from DashboardData.
 	 */
 	public async loadPersistedProjects(): Promise<void> {
 		const dashboardData = util.getStorageData(this._context);
@@ -149,8 +177,8 @@ export class ProjectRegistry {
 		for (const p of projects) {
 			const project = await createLibertyProjectFromPath(this._context, p.path, p.contextValue, this._projects);
 			if (project !== undefined) {
-				this._projects.set(p.path, project);
-				console.debug("Project " + p.path + " added to Liberty Tools");
+				this._addedProjects.set(p.path, project);
+				console.debug("Project " + p.path + " loaded into manually-added projects");
 			} else {
 				projectsToBeRemoved.push(p);
 			}

--- a/src/liberty/projectTreeProvider.ts
+++ b/src/liberty/projectTreeProvider.ts
@@ -2,7 +2,6 @@
  * IBM Confidential
  * Copyright IBM Corp. 2020, 2026
  */
-import * as fse from "fs-extra";
 import * as vscode from "vscode";
 import * as util from "../util/helperUtil";
 import { localize } from "../util/i18nUtil";
@@ -269,26 +268,10 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 		const context = this._registry.getContext();
 		const wsFolders = vscode.workspace.workspaceFolders ?? [];
 
-		// Clean up persisted projects whose files no longer exist
-		const persistedProjects = util.getStorageData(context).projects;
-		const persistedToRemove: typeof persistedProjects[0][] = [];
-		for (const p of persistedProjects) {
-			if (!fse.existsSync(p.path)) {
-				persistedToRemove.push(p);
-			}
-		}
-		if (persistedToRemove.length > 0) {
-			const dashboardData = util.getStorageData(context);
-			persistedToRemove.forEach(p => dashboardData.removeProject(p.path));
-			await util.saveStorageData(context, dashboardData);
-		}
-		const validPersisted = persistedProjects.filter(p => !persistedToRemove.includes(p));
-
-		const { projects, rootProjects } = await discoverWorkspace(
+		const { projects, rootProjects, rejectedBuildFiles } = await discoverWorkspace(
 			context,
 			wsFolders,
 			this._registry.getProjects(),
-			validPersisted,
 			(partial, foldersComplete, totalFolders) => {
 				// Progressive tree update after each folder
 				this._registry.setProjects(new Map(partial));
@@ -299,6 +282,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 
 		this._registry.setProjects(projects);
 		this._registry.setRootProjects(this.sortRoots(rootProjects));
+		this._registry.setRejectedBuildFiles(rejectedBuildFiles);
 		console.log(`[perf] updateProjects total: ${Date.now() - t0}ms  (${projects.size} projects, ${rootProjects.length} roots)`);
 	}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,7 +34,7 @@
     "error.parsing.pom": "Unable to parse pom file. The error is {0}.",
     "refreshing.liberty.dashboard": "Refreshing Liberty Tools projects...",
     "no.liberty.project.found.in.empty.workspace": "No Liberty project was found in empty workspace.",
-    "add.project.manually.no.projects.available.to.add": "No workspace folders are available to be added to Liberty Tools.",
+    "add.project.manually.no.projects.available.to.add": "All detected build files are already registered. No projects available to add manually.",
     "add.project.manually.message.0": "The selected project at {0} is added to Liberty Tools.",
     "add.project.manually.message.1": "The selected project at {0} already exists in Liberty Tools.",
     "add.project.manually.message.2": "The selected project at {0} is not a Maven or Gradle project.",

--- a/src/test/unit/manualAdd.test.ts
+++ b/src/test/unit/manualAdd.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Unit tests for manual project add/remove behavior.
+ *
+ * Behaviors covered:
+ *   1. getUnregisteredBuildFolders() returns folders for rejected build files only
+ *   2. After addToAddedProjects(), that folder no longer appears in getUnregisteredBuildFolders()
+ *   3. getChildren(root) includes manually added projects alongside auto-detected ones
+ *   4. getAddedProjects() contains only manually added projects, not auto-detected ones
+ */
+import { strict as assert } from "assert";
+import * as path from "path";
+import { ProjectRegistry } from "../../liberty/projectRegistry";
+import { LibertyProject } from "../../liberty/libertyProject";
+import { LIBERTY_PROJECT_MAVEN, LIBERTY_PROJECT_GRADLE } from "../../definitions/constants";
+import * as vscode from "vscode";
+
+// ── Minimal context mock ──────────────────────────────────────────────────────
+
+function makeContext(): vscode.ExtensionContext {
+    const store = new Map<string, any>();
+    return {
+        workspaceState: {
+            get: (key: string, defaultValue?: any) => store.has(key) ? store.get(key) : defaultValue,
+            update: (key: string, value: any) => { store.set(key, value); return Promise.resolve(); },
+        },
+        globalState: {
+            get: (key: string, defaultValue?: any) => store.has(key) ? store.get(key) : defaultValue,
+            update: (key: string, value: any) => { store.set(key, value); return Promise.resolve(); },
+        },
+        extensionPath: "/mock",
+    } as any;
+}
+
+function makeProject(buildFilePath: string, type: string): LibertyProject {
+    return new LibertyProject(
+        makeContext(),
+        path.basename(path.dirname(buildFilePath)),
+        vscode.TreeItemCollapsibleState.None,
+        buildFilePath,
+        "start",
+        type,
+        undefined,
+        undefined,
+    );
+}
+
+describe("manual add: getAddedProjects", () => {
+    it("contains only manually added projects, not auto-detected ones", () => {
+        const registry = new ProjectRegistry(makeContext());
+
+        const autoPath = "/ws/app-a/pom.xml";
+        const manualPath = "/ws/app-b/pom.xml";
+
+        const projects = new Map<string, LibertyProject>();
+        projects.set(autoPath, makeProject(autoPath, LIBERTY_PROJECT_MAVEN));
+        registry.setProjects(projects);
+
+        const manualProject = makeProject(manualPath, LIBERTY_PROJECT_MAVEN);
+        registry.addToAddedProjects(manualProject);
+
+        const added = registry.getAddedProjects();
+        assert.equal(added.length, 1);
+        assert.equal(added[0].getPath(), manualPath);
+    });
+
+    it("removes a project from added list when removeFromAddedProjects is called", () => {
+        const registry = new ProjectRegistry(makeContext());
+
+        const manualPath = "/ws/app-b/pom.xml";
+        registry.addToAddedProjects(makeProject(manualPath, LIBERTY_PROJECT_MAVEN));
+        assert.equal(registry.getAddedProjects().length, 1);
+
+        registry.removeFromAddedProjects(manualPath);
+        assert.equal(registry.getAddedProjects().length, 0);
+    });
+});
+
+describe("manual add: getUnregisteredBuildFolders", () => {
+    it("returns folders for build files not in _projects", () => {
+        const registry = new ProjectRegistry(makeContext());
+
+        const acceptedPath = "/ws/app-a/pom.xml";
+        const rejectedPath = "/ws/app-b/pom.xml";
+
+        const projects = new Map<string, LibertyProject>();
+        projects.set(acceptedPath, makeProject(acceptedPath, LIBERTY_PROJECT_MAVEN));
+        registry.setProjects(projects);
+        registry.setRejectedBuildFiles([acceptedPath, rejectedPath]);
+
+        const result = registry.getUnregisteredBuildFolders();
+        assert.deepEqual(result, [path.dirname(rejectedPath)]);
+    });
+
+    it("excludes a folder once its project has been manually added", () => {
+        const registry = new ProjectRegistry(makeContext());
+
+        const rejectedPath = "/ws/app-b/pom.xml";
+        registry.setProjects(new Map());
+        registry.setRejectedBuildFiles([rejectedPath]);
+
+        assert.equal(registry.getUnregisteredBuildFolders().length, 1);
+
+        registry.addToAddedProjects(makeProject(rejectedPath, LIBERTY_PROJECT_MAVEN));
+
+        assert.equal(registry.getUnregisteredBuildFolders().length, 0);
+    });
+});


### PR DESCRIPTION
## Context
Manual additions for Liberty Projects existed to provide users a manual option in the event auto detection failed to pick up a project. With multi-module support, we additionally cover plugin inheritance that were edge cases before. 

We'll keep the command so we don't regress, but we'll at least release some of the valuable icon space on the view. We will need an update to the documentation #633