### PR TITLE
init dashboard status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@types/mocha": "10.0.0",
 				"@types/node": "20.0.0",
 				"@types/selenium-webdriver": "4.1.22",
-				"@types/vscode": "1.42.0",
+				"@types/vscode": "^1.93.0",
 				"@typescript-eslint/eslint-plugin": "8.0.0",
 				"@typescript-eslint/parser": "8.0.0",
 				"@vscode/test-electron": "2.4.0",
@@ -1263,9 +1263,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
-			"integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
+			"version": "1.93.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
+			"integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
 		"@types/mocha": "10.0.0",
 		"@types/node": "20.0.0",
 		"@types/selenium-webdriver": "4.1.22",
-		"@types/vscode": "1.42.0",
+		"@types/vscode": "^1.93.0",
 		"@typescript-eslint/eslint-plugin": "8.0.0",
 		"@typescript-eslint/parser": "8.0.0",
 		"axios": "1.15.2",

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -27,6 +27,25 @@ import { getCommandForMaven, getCommandForGradle, defaultWindowsShell } from "..
 
 export const terminals: { [libProjectId: number]: LibertyProject } = {};
 
+function waitForShellIntegration(terminal: vscode.Terminal, timeoutMs = 5000): Promise<vscode.TerminalShellIntegration | undefined> {
+    if (terminal.shellIntegration) { return Promise.resolve(terminal.shellIntegration); }
+    return new Promise(resolve => {
+        const timer = setTimeout(() => {
+            sub.dispose();
+            console.warn(`[waitForShellIntegration] timed out after ${timeoutMs}ms for terminal=${terminal.name}`);
+            resolve(undefined);
+        }, timeoutMs);
+        const sub = vscode.window.onDidChangeTerminalShellIntegration(event => {
+            console.log(`[waitForShellIntegration] onDidChangeTerminalShellIntegration fired, terminal=${event.terminal.name}, match=${event.terminal === terminal}`);
+            if (event.terminal === terminal) {
+                clearTimeout(timer);
+                sub.dispose();
+                resolve(event.shellIntegration);
+            }
+        });
+    });
+}
+
 class LibertyProjectQuickPickItem implements QuickPickItem {
 
     project: LibertyProject | undefined;
@@ -69,19 +88,19 @@ export async function openBuildFile(libProject?: LibertyProject): Promise<void> 
 
 // List all liberty dev commands, triggered by hotkey (Shift+Alt+L)
 const COMMAND_TITLES = new Map<string, string>([
-    [localize("hotkey.commands.title.refresh"),                      CMD_EXPLORER_REFRESH],
-    [localize("hotkey.commands.title.start"),                        CMD_START],
-    [localize("hotkey.commands.title.start.custom"),                 CMD_CUSTOM],
-    [localize("hotkey.commands.title.start.in.container"),           CMD_START_CONTAINER],
-    [localize("hotkey.commands.title.debug"),                        CMD_DEBUG],
-    [localize("hotkey.commands.title.stop"),                         CMD_STOP],
-    [localize("hotkey.commands.title.run.tests"),                    CMD_RUN_TESTS],
+    [localize("hotkey.commands.title.refresh"), CMD_EXPLORER_REFRESH],
+    [localize("hotkey.commands.title.start"), CMD_START],
+    [localize("hotkey.commands.title.start.custom"), CMD_CUSTOM],
+    [localize("hotkey.commands.title.start.in.container"), CMD_START_CONTAINER],
+    [localize("hotkey.commands.title.debug"), CMD_DEBUG],
+    [localize("hotkey.commands.title.stop"), CMD_STOP],
+    [localize("hotkey.commands.title.run.tests"), CMD_RUN_TESTS],
     [localize("hotkey.commands.title.view.integration.test.report"), CMD_OPEN_FAILSAFE_REPORT],
-    [localize("hotkey.commands.title.view.unit.test.report"),        CMD_OPEN_SUREFIRE_REPORT],
-    [localize("hotkey.commands.title.view.test.report"),             CMD_OPEN_GRADLE_TEST_REPORT],
-    [localize("hotkey.commands.title.add.project"),                  CMD_ADD_PROJECT],
-    [localize("hotkey.commands.title.remove.project"),               CMD_REMOVE_PROJECT],
-    [localize("hotkey.commands.title.open.build.file"),              CMD_OPEN_BUILD_FILE],
+    [localize("hotkey.commands.title.view.unit.test.report"), CMD_OPEN_SUREFIRE_REPORT],
+    [localize("hotkey.commands.title.view.test.report"), CMD_OPEN_GRADLE_TEST_REPORT],
+    [localize("hotkey.commands.title.add.project"), CMD_ADD_PROJECT],
+    [localize("hotkey.commands.title.remove.project"), CMD_REMOVE_PROJECT],
+    [localize("hotkey.commands.title.open.build.file"), CMD_OPEN_BUILD_FILE],
 ]);
 
 export async function listAllCommands(): Promise<void> {
@@ -127,15 +146,25 @@ async function sendDevModeCommand(
     mavenGoal: string,
     gradleTask: string,
     customCommand?: string
-): Promise<void> {
+): Promise<boolean> {
+    let cmd: string | undefined;
     if (isMaven(project.getContextValue())) {
         const pomPath = project.parent ? project.parent.getPath() : project.getPath();
         const artifactId = project.parent ? project.artifactId : undefined;
-        const cmd = await getCommandForMaven(pomPath, mavenGoal, project.getTerminalType(), customCommand, artifactId);
-        terminal.sendText(cmd);
+        cmd = await getCommandForMaven(pomPath, mavenGoal, project.getTerminalType(), customCommand, artifactId);
     } else if (isGradle(project.getContextValue())) {
-        const cmd = await getCommandForGradle(project.getPath(), gradleTask, project.getTerminalType(), customCommand);
+        cmd = await getCommandForGradle(project.getPath(), gradleTask, project.getTerminalType(), customCommand);
+    }
+    if (cmd === undefined) { return false; }
+    const si = terminal.shellIntegration ?? await waitForShellIntegration(terminal);
+    if (si) {
+        console.log(`[sendDevModeCommand] using shellIntegration.executeCommand for ${project.label}`);
+        si.executeCommand(cmd);
+        return true;
+    } else {
+        console.log(`[sendDevModeCommand] shellIntegration not ready after timeout, falling back to sendText for ${project.label}`);
         terminal.sendText(cmd);
+        return false;
     }
 }
 
@@ -156,8 +185,8 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
     console.log(localize("starting.liberty.dev.on", targetProject.getLabel()));
     const terminal = ensureTerminal(targetProject);
     if (terminal !== undefined) {
-        await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV);
-        targetProject.isDevMode = true;
+        const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV);
+        targetProject.setState(tracked ? "starting" : "started");
         projectProvider.notifyDevModeChanged(targetProject);
     }
 }
@@ -255,7 +284,7 @@ export async function stopDevMode(libProject?: LibertyProject | undefined): Prom
         terminal.show();
         terminal.sendText("exit");
         terminal.dispose();
-        targetProject.isDevMode = false;
+        targetProject.setState("stopping");
         projectProvider.notifyDevModeChanged(targetProject);
     } else {
         const message = localize("liberty.dev.not.started.on", targetProject.getLabel());
@@ -419,8 +448,8 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
                 await helperUtil.saveStorageData(registry.getContext(), dashboardData);
             }
 
-            await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, customCommand);
-            targetProject.isDevMode = true;
+            const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, customCommand);
+            targetProject.setState(tracked ? "starting" : "started");
             projectProvider.notifyDevModeChanged(targetProject);
         }
     }
@@ -442,8 +471,8 @@ export async function startContainerDevMode(libProject?: LibertyProject | undefi
 
     const terminal = ensureTerminal(targetProject);
     if (terminal !== undefined) {
-        await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEVC, GRADLE_TASK_DEVC);
-        targetProject.isDevMode = true;
+        const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEVC, GRADLE_TASK_DEVC);
+        targetProject.setState(tracked ? "starting" : "started");
         projectProvider.notifyDevModeChanged(targetProject);
     }
 }
@@ -514,10 +543,9 @@ export async function deleteTerminal(terminal: vscode.Terminal): Promise<void> {
     try {
         const pid = await terminal.processId;
         const libProject = terminals[Number(pid)];
-        libProject.isDevMode = false;
+        libProject.deleteTerminal();
         const pp = ProjectTreeProvider.getInstance();
         if (pp) { pp.notifyDevModeChanged(libProject); }
-        libProject.deleteTerminal();
     } catch {
         console.error(localize("unable.to.delete.terminal", terminal.name));
     }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -9,7 +9,7 @@ import * as vscode from "vscode";
 import * as helperUtil from "../util/helperUtil";
 import { localize } from "../util/i18nUtil";
 import { QuickPickItem } from "vscode";
-import { LibertyProject } from "./libertyProject";
+import { LibertyProject, DevModeState } from "./libertyProject";
 import { ProjectRegistry } from "./projectRegistry";
 import { ProjectTreeProvider } from "./projectTreeProvider";
 import { getReport } from "../util/helperUtil";
@@ -186,7 +186,7 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
     const terminal = ensureTerminal(targetProject);
     if (terminal !== undefined) {
         const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV);
-        targetProject.setState(tracked ? "starting" : "started");
+        targetProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
         projectProvider.notifyDevModeChanged(targetProject);
     }
 }
@@ -284,7 +284,7 @@ export async function stopDevMode(libProject?: LibertyProject | undefined): Prom
         terminal.show();
         terminal.sendText("exit");
         terminal.dispose();
-        targetProject.setState("stopping");
+        targetProject.setState(DevModeState.Stopping);
         projectProvider.notifyDevModeChanged(targetProject);
     } else {
         const message = localize("liberty.dev.not.started.on", targetProject.getLabel());
@@ -449,7 +449,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             }
 
             const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, customCommand);
-            targetProject.setState(tracked ? "starting" : "started");
+            targetProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
             projectProvider.notifyDevModeChanged(targetProject);
         }
     }
@@ -472,7 +472,7 @@ export async function startContainerDevMode(libProject?: LibertyProject | undefi
     const terminal = ensureTerminal(targetProject);
     if (terminal !== undefined) {
         const tracked = await sendDevModeCommand(terminal, targetProject, MAVEN_GOAL_DEVC, GRADLE_TASK_DEVC);
-        targetProject.setState(tracked ? "starting" : "started");
+        targetProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
         projectProvider.notifyDevModeChanged(targetProject);
     }
 }

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -13,7 +13,11 @@ const MAVEN_ICON = "maven-tag.png";
 const GRADLE_ICON = "gradle-tag-1.png";
 const OL_LOGO_ICON = "ol_logo.png";
 
-export type DevModeState = "starting" | "started" | "stopping";
+export enum DevModeState {
+	Starting = "starting",
+	Running  = "running",
+	Stopping = "stopping",
+}
 
 /**
  * CWWKF0011I = server ready (starting → started)
@@ -140,8 +144,8 @@ export class LibertyProject extends vscode.TreeItem {
 		(async () => {
 			for await (const chunk of stream) {
 				if (disposed) { break; }
-				if (chunk.includes(LIBERTY_MSG_STARTED) && this.state === "starting") {
-					this.setState("started");
+				if (chunk.includes(LIBERTY_MSG_STARTED) && this.state === DevModeState.Starting) {
+					this.setState(DevModeState.Running);
 					onStateChange(this);
 					vscode.window.showInformationMessage(`Liberty server started: ${this.label}`);
 				} else if (chunk.includes(LIBERTY_MSG_STOPPED)) {

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -13,15 +13,26 @@ const MAVEN_ICON = "maven-tag.png";
 const GRADLE_ICON = "gradle-tag-1.png";
 const OL_LOGO_ICON = "ol_logo.png";
 
+export type DevModeState = "starting" | "started" | "stopping";
+
+/**
+ * CWWKF0011I = server ready (starting → started)
+ * CWWKE0036I = server stopped (stopping → cleared)
+ */
+export const LIBERTY_MSG_STARTED = "CWWKF0011I";
+export const LIBERTY_MSG_STOPPED = "CWWKE0036I";
+
 export class LibertyProject extends vscode.TreeItem {
 	public parent?: LibertyProject;
 	public children: LibertyProject[] = [];
 	public isAggregator: boolean = false;
 	public isLibertyEnabled: boolean = false;
-	public isDevMode: boolean = false;
 	public artifactId: string = "";
 	public parentArtifactId?: string;
 	public baseContextValue: string;
+
+	// disposable for the project shell execution listener. disposes on terminal close.
+	private _monitorDisposable?: vscode.Disposable;
 
 	constructor(
 		private _context: vscode.ExtensionContext,
@@ -29,7 +40,7 @@ export class LibertyProject extends vscode.TreeItem {
 		public collapsibleState: vscode.TreeItemCollapsibleState,
 		// tslint:disable-next-line: no-shadowed-variable
 		public readonly path: string,
-		public state: string,
+		public state: DevModeState | undefined,
 		// valid context values are defined in src/definitions/constants.ts
 		public contextValue: string,
 		public terminal?: vscode.Terminal,
@@ -40,7 +51,7 @@ export class LibertyProject extends vscode.TreeItem {
 		this.tooltip = this.path;
 		this.children = [];
 		this.baseContextValue = contextValue;
-		this.contextValue = computeContextValue(contextValue, false);
+		this.contextValue = computeContextValue(contextValue, undefined);
 	}
 
 	private EXPLORER_ICON = this.setExplorerIcon();
@@ -58,12 +69,13 @@ export class LibertyProject extends vscode.TreeItem {
 		this.label = label;
 	}
 
-	public getState(): string {
-		return `${this.state}`;
+	public getState(): DevModeState | undefined {
+		return this.state;
 	}
 
-	public setState(state: string): void {
+	public setState(state: DevModeState | undefined): void {
 		this.state = state;
+		this.contextValue = computeContextValue(this.baseContextValue, state);
 	}
 
 	public getPath(): string {
@@ -76,7 +88,7 @@ export class LibertyProject extends vscode.TreeItem {
 
 	public setContextValue(contextValue: string): void {
 		this.baseContextValue = contextValue;
-		this.contextValue = computeContextValue(contextValue, this.isDevMode);
+		this.contextValue = computeContextValue(contextValue, this.state);
 	}
 
 	public getTerminal(): vscode.Terminal | undefined {
@@ -106,7 +118,7 @@ export class LibertyProject extends vscode.TreeItem {
 					env = { JAVA_HOME: javaHome };
 				}
 			}
-			const terminal = vscode.window.createTerminal({ cwd: projectHome, name: this.label + " (liberty dev)", env: env, message: "" } as any);
+			const terminal = vscode.window.createTerminal({ cwd: projectHome, name: this.label + " (liberty dev)", env: env } as vscode.TerminalOptions);
 			return terminal;
 		}
 		return undefined;
@@ -114,6 +126,38 @@ export class LibertyProject extends vscode.TreeItem {
 
 	public deleteTerminal(): void {
 		delete this.terminal;
+		this.cleanupShellListener();
+		this.setState(undefined);
+	}
+
+	public enableShellListener(execution: vscode.TerminalShellExecution, onStateChange: (project: LibertyProject) => void): void {
+		console.log(`[startMonitoring] called for ${this.label}, state=${this.state}`);
+		this.cleanupShellListener();
+		const stream = execution.read();
+		let disposed = false;
+		const disposable = { dispose: () => { disposed = true; } };
+		this._monitorDisposable = disposable;
+		(async () => {
+			for await (const chunk of stream) {
+				if (disposed) { break; }
+				if (chunk.includes(LIBERTY_MSG_STARTED) && this.state === "starting") {
+					this.setState("started");
+					onStateChange(this);
+					vscode.window.showInformationMessage(`Liberty server started: ${this.label}`);
+				} else if (chunk.includes(LIBERTY_MSG_STOPPED)) {
+					this.setState(undefined);
+					onStateChange(this);
+					break;
+				}
+			}
+		})();
+	}
+
+	private cleanupShellListener(): void {
+		if (this._monitorDisposable) {
+			this._monitorDisposable.dispose();
+			this._monitorDisposable = undefined;
+		}
 	}
 
 	public setExplorerIcon() {
@@ -125,7 +169,7 @@ export class LibertyProject extends vscode.TreeItem {
 
 export async function createProject(context: vscode.ExtensionContext, buildFile: string, contextValue: string, xmlString?: string): Promise<LibertyProject> {
 	const label = await getLabelFromBuildFile(buildFile, xmlString);
-	const project: LibertyProject = new LibertyProject(context, label, vscode.TreeItemCollapsibleState.None, buildFile, "start", contextValue, undefined, undefined);
+	const project: LibertyProject = new LibertyProject(context, label, vscode.TreeItemCollapsibleState.None, buildFile, undefined, contextValue, undefined, undefined);
 	// command: "extension.open.project",
 	// title: "",
 	// arguments: [buildFile],

--- a/src/liberty/projectDiscovery.ts
+++ b/src/liberty/projectDiscovery.ts
@@ -266,7 +266,7 @@ async function discoverProjects(
 				if (existing.getLabel() !== gradleLabel) { existing.setLabel(gradleLabel); }
 				projectsMap.set(entry.path, existing);
 			} else {
-				const project = new LibertyProject(context, gradleLabel, vscode.TreeItemCollapsibleState.None, entry.path, "start", buildFile.getProjectType(), undefined, undefined);
+				const project = new LibertyProject(context, gradleLabel, vscode.TreeItemCollapsibleState.None, entry.path, undefined, buildFile.getProjectType(), undefined, undefined);
 				projectsMap.set(entry.path, project);
 			}
 			visitedPaths.add(entry.path);

--- a/src/liberty/projectRegistry.ts
+++ b/src/liberty/projectRegistry.ts
@@ -11,6 +11,7 @@ import { DashboardData } from "./dashboard";
 import { BaseLibertyProject } from "./baseLibertyProject";
 import { LibertyProject, createProject } from "./libertyProject";
 import { createLibertyProjectFromPath } from "./projectDiscovery";
+import { ProjectTreeProvider } from "./projectTreeProvider";
 
 /**
  * Singleton registry: single source of truth for discovered LibertyProject objects.
@@ -32,6 +33,29 @@ export class ProjectRegistry {
 
 	constructor(context: vscode.ExtensionContext) {
 		this._context = context;
+		this._registerShellIntegrationListener();
+	}
+
+	private _registerShellIntegrationListener(): void {
+		console.log(`[ProjectRegistry] _registerShellIntegrationListener called, API available=${typeof vscode.window.onDidStartTerminalShellExecution === "function"}`);
+		if (typeof vscode.window.onDidStartTerminalShellExecution !== "function") { return; }
+		vscode.window.onDidStartTerminalShellExecution(event => {
+			const project = this._findProjectByTerminal(event.terminal);
+			if (project === undefined) { return; }
+			const pp = ProjectTreeProvider.getInstance();
+			project.enableShellListener(event.execution, (changed) => {
+				if (pp) { pp.notifyDevModeChanged(changed); }
+			});
+		});
+	}
+
+	private _findProjectByTerminal(terminal: vscode.Terminal): LibertyProject | undefined {
+		for (const project of [...this._projects.values(), ...this._addedProjects.values()]) {
+			if (project.getTerminal() === terminal) {
+				return project;
+			}
+		}
+		return undefined;
 	}
 
 	public static getInstance(): ProjectRegistry {

--- a/src/liberty/projectTreeProvider.ts
+++ b/src/liberty/projectTreeProvider.ts
@@ -5,14 +5,15 @@
 import * as vscode from "vscode";
 import * as util from "../util/helperUtil";
 import { localize } from "../util/i18nUtil";
-import { devModeRequirement } from "../util/helperUtil";
+import { devModeRequirement, computeContextValue } from "../util/helperUtil";
 import { UNTITLED_WORKSPACE, SORT_ORDER_KEY, SortOrder } from "../definitions/constants";
 import { LibertyProject } from "./libertyProject";
 import { ProjectRegistry } from "./projectRegistry";
 import { discoverWorkspace, sortByWorkspaceOrder } from "./projectDiscovery";
 
-// URI scheme used to signal dev-mode state to the FileDecorationProvider (enables green UI)
-// Format: liberty-dev://running/<encoded-project-path>
+// URI scheme used to signal dev-mode state to the FileDecorationProvider
+// Format: liberty-dev://<state>/<encoded-project-path>
+// Authorities: "running" | "starting" | "stopping"
 const LIBERTY_DEV_SCHEME = "liberty-dev";
 
 export class LibertyDevDecorationProvider {
@@ -24,13 +25,26 @@ export class LibertyDevDecorationProvider {
 	}
 
 	provideFileDecoration(uri: vscode.Uri): { color: vscode.ThemeColor; tooltip: string } | undefined {
-		if (uri.scheme === LIBERTY_DEV_SCHEME && uri.authority === "running") {
-			return {
-				color: new vscode.ThemeColor("debugIcon.startForeground"),
-				tooltip: "Dev mode is running",
-			};
+		if (uri.scheme !== LIBERTY_DEV_SCHEME) { return undefined; }
+		switch (uri.authority) {
+			case "running":
+				return {
+					color: new vscode.ThemeColor("debugIcon.startForeground"),
+					tooltip: "Dev mode is running",
+				};
+			case "starting":
+				return {
+					color: new vscode.ThemeColor("charts.yellow"),
+					tooltip: "Liberty server is starting",
+				};
+			case "stopping":
+				return {
+					color: new vscode.ThemeColor("charts.yellow"),
+					tooltip: "Liberty server is stopping",
+				};
+			default:
+				return undefined;
 		}
-		return undefined;
 	}
 }
 
@@ -112,18 +126,26 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 	 * Update the tree item to reflect the new dev mode state.
 	 */
 	public notifyDevModeChanged(project: LibertyProject): void {
-		if (project.isDevMode) {
-			project.description = localize("liberty.view.running");
-			project.resourceUri = vscode.Uri.parse(
-				`${LIBERTY_DEV_SCHEME}://running/${encodeURIComponent(project.path)}`
-			);
-		} else {
-			project.description = undefined;
-			project.resourceUri = undefined;
+		const encoded = encodeURIComponent(project.path);
+		switch (project.state) {
+			case "starting":
+				project.description = localize("liberty.view.starting");
+				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://starting/${encoded}`);
+				break;
+			case "started":
+				project.description = localize("liberty.view.running");
+				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://running/${encoded}`);
+				break;
+			case "stopping":
+				project.description = localize("liberty.view.stopping");
+				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://stopping/${encoded}`);
+				break;
+			default:
+				project.description = undefined;
+				project.resourceUri = undefined;
+				break;
 		}
-		project.contextValue = project.isDevMode
-			? `${project.baseContextValue}:running`
-			: project.baseContextValue;
+		project.contextValue = computeContextValue(project.baseContextValue, project.state);
 		this._onDidChangeTreeData.fire(project);
 		if (project.resourceUri) {
 			this.decorationProvider.notify(project.resourceUri);
@@ -247,7 +269,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 			const req = devModeRequirement(command);
 			const eligible = req === undefined
 				? libertyChildren
-				: libertyChildren.filter(c => c.isDevMode === req);
+				: libertyChildren.filter(c => req === true ? c.state !== undefined : c.state === undefined);
 			if (eligible.length === 0) {
 				const msg = req === true
 					? localize("no.modules.currently.running", project.label)

--- a/src/liberty/projectTreeProvider.ts
+++ b/src/liberty/projectTreeProvider.ts
@@ -7,7 +7,7 @@ import * as util from "../util/helperUtil";
 import { localize } from "../util/i18nUtil";
 import { devModeRequirement, computeContextValue } from "../util/helperUtil";
 import { UNTITLED_WORKSPACE, SORT_ORDER_KEY, SortOrder } from "../definitions/constants";
-import { LibertyProject } from "./libertyProject";
+import { LibertyProject, DevModeState } from "./libertyProject";
 import { ProjectRegistry } from "./projectRegistry";
 import { discoverWorkspace, sortByWorkspaceOrder } from "./projectDiscovery";
 
@@ -128,15 +128,15 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 	public notifyDevModeChanged(project: LibertyProject): void {
 		const encoded = encodeURIComponent(project.path);
 		switch (project.state) {
-			case "starting":
+			case DevModeState.Starting:
 				project.description = localize("liberty.view.starting");
 				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://starting/${encoded}`);
 				break;
-			case "started":
+			case DevModeState.Running:
 				project.description = localize("liberty.view.running");
 				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://running/${encoded}`);
 				break;
-			case "stopping":
+			case DevModeState.Stopping:
 				project.description = localize("liberty.view.stopping");
 				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://stopping/${encoded}`);
 				break;
@@ -158,7 +158,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 	private _updateAggregatorDescription(aggregator: LibertyProject): void {
 		const descendants = this._registry.findLibertyDescendants(aggregator);
 		const total = descendants.length;
-		const running = descendants.filter(d => d.state === "started").length;
+		const running = descendants.filter(d => d.state === DevModeState.Running).length;
 		aggregator.description = running > 0 ? `${running}/${total} Running...` : undefined;
 		this._onDidChangeTreeData.fire(aggregator);
 		if (aggregator.parent) {

--- a/src/liberty/projectTreeProvider.ts
+++ b/src/liberty/projectTreeProvider.ts
@@ -123,7 +123,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 	}
 
 	/**
-	 * Update the tree item to reflect the new dev mode state.
+	 * Update the tree item to reflect the new dev mode state. Also update aggregator
 	 */
 	public notifyDevModeChanged(project: LibertyProject): void {
 		const encoded = encodeURIComponent(project.path);
@@ -149,6 +149,20 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 		this._onDidChangeTreeData.fire(project);
 		if (project.resourceUri) {
 			this.decorationProvider.notify(project.resourceUri);
+		}
+		if (project.parent) {
+			this._updateAggregatorDescription(project.parent);
+		}
+	}
+
+	private _updateAggregatorDescription(aggregator: LibertyProject): void {
+		const descendants = this._registry.findLibertyDescendants(aggregator);
+		const total = descendants.length;
+		const running = descendants.filter(d => d.state === "started").length;
+		aggregator.description = running > 0 ? `${running}/${total} Running...` : undefined;
+		this._onDidChangeTreeData.fire(aggregator);
+		if (aggregator.parent) {
+			this._updateAggregatorDescription(aggregator.parent);
 		}
 	}
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,6 +11,8 @@
     "jakarta.ls.thumbs.up": "LSP4Jakarta $(thumbsup)",
     "jakarta.ls.started": "Language Server for Jakarta EE started.",
     "liberty.view.running": "Running...",
+    "liberty.view.starting": "Starting...",
+    "liberty.view.stopping": "Stopping...",
     "no.liberty.projects.found": "No Liberty projects found.",
     "starting.liberty.dev.on": "Starting Liberty dev mode on {0}.",
     "cannot.start.liberty.dev": "Cannot start Liberty dev mode on an undefined project.",

--- a/src/test/unit/contextValue.test.ts
+++ b/src/test/unit/contextValue.test.ts
@@ -4,6 +4,7 @@
  */
 import { strict as assert } from "assert";
 import { computeContextValue } from "../../util/helperUtil";
+import { DevModeState } from "../../liberty/libertyProject";
 
 // ---------------------------------------------------------------------------
 // computeContextValue
@@ -17,22 +18,22 @@ describe("computeContextValue — state undefined (stopped)", () => {
 
 describe("computeContextValue — state 'started'", () => {
     it("appends :running when started", () => {
-        assert.equal(computeContextValue("libertyProject:maven", "started"), "libertyProject:maven:running");
+        assert.equal(computeContextValue("libertyProject:maven", DevModeState.Running), "libertyProject:maven:running");
     });
 });
 
 describe("computeContextValue — state 'starting' or 'stopping'", () => {
     it("does not append :running when starting", () => {
-        assert.equal(computeContextValue("libertyProject:maven", "starting"), "libertyProject:maven");
+        assert.equal(computeContextValue("libertyProject:maven", DevModeState.Starting), "libertyProject:maven");
     });
     it("does not append :running when stopping", () => {
-        assert.equal(computeContextValue("libertyProject:maven", "stopping"), "libertyProject:maven");
+        assert.equal(computeContextValue("libertyProject:maven", DevModeState.Stopping), "libertyProject:maven");
     });
 });
 
 describe("computeContextValue — aggregator", () => {
     it("never appends :running to an aggregator", () => {
-        assert.equal(computeContextValue("libertyProject:maven:aggregator", "started"), "libertyProject:maven:aggregator");
+        assert.equal(computeContextValue("libertyProject:maven:aggregator", DevModeState.Running), "libertyProject:maven:aggregator");
     });
 });
 

--- a/src/test/unit/contextValue.test.ts
+++ b/src/test/unit/contextValue.test.ts
@@ -9,21 +9,30 @@ import { computeContextValue } from "../../util/helperUtil";
 // computeContextValue
 // ---------------------------------------------------------------------------
 
-describe("computeContextValue — isDevMode false", () => {
+describe("computeContextValue — state undefined (stopped)", () => {
     it("returns base unchanged when not running", () => {
-        assert.equal(computeContextValue("libertyProject:maven", false), "libertyProject:maven");
+        assert.equal(computeContextValue("libertyProject:maven", undefined), "libertyProject:maven");
     });
 });
 
-describe("computeContextValue — isDevMode true", () => {
-    it("appends :running when running", () => {
-        assert.equal(computeContextValue("libertyProject:maven", true), "libertyProject:maven:running");
+describe("computeContextValue — state 'started'", () => {
+    it("appends :running when started", () => {
+        assert.equal(computeContextValue("libertyProject:maven", "started"), "libertyProject:maven:running");
+    });
+});
+
+describe("computeContextValue — state 'starting' or 'stopping'", () => {
+    it("does not append :running when starting", () => {
+        assert.equal(computeContextValue("libertyProject:maven", "starting"), "libertyProject:maven");
+    });
+    it("does not append :running when stopping", () => {
+        assert.equal(computeContextValue("libertyProject:maven", "stopping"), "libertyProject:maven");
     });
 });
 
 describe("computeContextValue — aggregator", () => {
     it("never appends :running to an aggregator", () => {
-        assert.equal(computeContextValue("libertyProject:maven:aggregator", true), "libertyProject:maven:aggregator");
+        assert.equal(computeContextValue("libertyProject:maven:aggregator", "started"), "libertyProject:maven:aggregator");
     });
 });
 

--- a/src/test/unit/devModeState.test.ts
+++ b/src/test/unit/devModeState.test.ts
@@ -3,7 +3,7 @@
  * These tests run with plain mocha + chai — no VS Code instance required.
  */
 import { strict as assert } from "assert";
-import { LibertyProject } from "../../liberty/libertyProject";
+import { LibertyProject, DevModeState } from "../../liberty/libertyProject";
 import { filterProjects, devModeRequirement } from "../../util/helperUtil";
 
 // Minimal vscode.ExtensionContext stub — only what LibertyProject constructor needs
@@ -34,25 +34,25 @@ describe("LibertyProject.state", () => {
 
     it("setState('starting') sets state to starting", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("starting");
-        assert.equal(project.state, "starting");
+        project.setState(DevModeState.Starting);
+        assert.equal(project.state, DevModeState.Starting);
     });
 
     it("setState('started') sets state to started", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
-        assert.equal(project.state, "started");
+        project.setState(DevModeState.Running);
+        assert.equal(project.state, DevModeState.Running);
     });
 
     it("setState('stopping') sets state to stopping", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("stopping");
-        assert.equal(project.state, "stopping");
+        project.setState(DevModeState.Stopping);
+        assert.equal(project.state, DevModeState.Stopping);
     });
 
     it("setState(undefined) clears state back to stopped", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         project.setState(undefined);
         assert.equal(project.state, undefined);
     });
@@ -65,13 +65,13 @@ describe("LibertyProject.state", () => {
 describe("filterProjects - liberty.dev.stop", () => {
     it("includes projects where state is 'started'", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
     });
 
     it("includes projects where state is 'starting'", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("starting");
+        project.setState(DevModeState.Starting);
         assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
     });
 
@@ -88,7 +88,7 @@ describe("filterProjects - liberty.dev.stop", () => {
 describe("filterProjects - liberty.dev.run.tests", () => {
     it("includes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 1);
     });
 
@@ -105,7 +105,7 @@ describe("filterProjects - liberty.dev.run.tests", () => {
 describe("filterProjects - liberty.dev.debug", () => {
     it("includes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.debug").length, 1);
     });
 
@@ -118,7 +118,7 @@ describe("filterProjects - liberty.dev.debug", () => {
 describe("filterProjects - liberty.dev.custom", () => {
     it("excludes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.custom").length, 0);
     });
 });
@@ -135,7 +135,7 @@ describe("filterProjects - liberty.dev.start.container", () => {
 
     it("excludes container projects where state is defined", () => {
         const project = makeProject("libertyProject:maven:container");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.start.container").length, 0);
     });
 
@@ -154,7 +154,7 @@ describe("filterProjects - liberty.dev.start", () => {
 
     it("excludes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.setState("started");
+        project.setState(DevModeState.Running);
         const result = filterProjects([project], "liberty.dev.start");
         assert.equal(result.length, 0);
     });

--- a/src/test/unit/devModeState.test.ts
+++ b/src/test/unit/devModeState.test.ts
@@ -1,5 +1,5 @@
 /*
- * Unit tests for isDevMode flag and filterProjects state-based filtering.
+ * Unit tests for DevModeState and filterProjects state-based filtering.
  * These tests run with plain mocha + chai — no VS Code instance required.
  */
 import { strict as assert } from "assert";
@@ -17,19 +17,44 @@ const stubContext: any = {
 const None = 0;
 
 function makeProject(contextValue: string): LibertyProject {
-    const p = new LibertyProject(stubContext, "test-project", None, "/fake/path", "start", contextValue);
+    const p = new LibertyProject(stubContext, "test-project", None, "/fake/path", undefined, contextValue);
     p.isLibertyEnabled = true;
     return p;
 }
 
 // ---------------------------------------------------------------------------
-// isDevMode flag
+// DevModeState
 // ---------------------------------------------------------------------------
 
-describe("LibertyProject.isDevMode", () => {
-    it("defaults to false on a new project", () => {
+describe("LibertyProject.state", () => {
+    it("defaults to undefined (stopped) on a new project", () => {
         const project = makeProject("libertyProject:maven");
-        assert.equal(project.isDevMode, false);
+        assert.equal(project.state, undefined);
+    });
+
+    it("setState('starting') sets state to starting", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState("starting");
+        assert.equal(project.state, "starting");
+    });
+
+    it("setState('started') sets state to started", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState("started");
+        assert.equal(project.state, "started");
+    });
+
+    it("setState('stopping') sets state to stopping", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState("stopping");
+        assert.equal(project.state, "stopping");
+    });
+
+    it("setState(undefined) clears state back to stopped", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState("started");
+        project.setState(undefined);
+        assert.equal(project.state, undefined);
     });
 });
 
@@ -38,15 +63,20 @@ describe("LibertyProject.isDevMode", () => {
 // ---------------------------------------------------------------------------
 
 describe("filterProjects - liberty.dev.stop", () => {
-    it("includes projects where isDevMode is true", () => {
+    it("includes projects where state is 'started'", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = true;
+        project.setState("started");
         assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
     });
 
-    it("excludes projects where isDevMode is false", () => {
+    it("includes projects where state is 'starting'", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = false;
+        project.setState("starting");
+        assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
+    });
+
+    it("excludes projects where state is undefined (stopped)", () => {
+        const project = makeProject("libertyProject:maven");
         assert.equal(filterProjects([project], "liberty.dev.stop").length, 0);
     });
 });
@@ -56,15 +86,14 @@ describe("filterProjects - liberty.dev.stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("filterProjects - liberty.dev.run.tests", () => {
-    it("includes projects where isDevMode is true", () => {
+    it("includes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = true;
+        project.setState("started");
         assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 1);
     });
 
-    it("excludes projects where isDevMode is false", () => {
+    it("excludes projects where state is undefined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = false;
         assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 0);
     });
 });
@@ -74,23 +103,22 @@ describe("filterProjects - liberty.dev.run.tests", () => {
 // ---------------------------------------------------------------------------
 
 describe("filterProjects - liberty.dev.debug", () => {
-    it("includes projects where isDevMode is true", () => {
+    it("includes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = true;
+        project.setState("started");
         assert.equal(filterProjects([project], "liberty.dev.debug").length, 1);
     });
 
-    it("excludes projects where isDevMode is false", () => {
+    it("excludes projects where state is undefined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = false;
         assert.equal(filterProjects([project], "liberty.dev.debug").length, 0);
     });
 });
 
 describe("filterProjects - liberty.dev.custom", () => {
-    it("excludes projects where isDevMode is true", () => {
+    it("excludes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = true;
+        project.setState("started");
         assert.equal(filterProjects([project], "liberty.dev.custom").length, 0);
     });
 });
@@ -100,36 +128,33 @@ describe("filterProjects - liberty.dev.custom", () => {
 // ---------------------------------------------------------------------------
 
 describe("filterProjects - liberty.dev.start.container", () => {
-    it("includes container projects where isDevMode is false", () => {
+    it("includes container projects where state is undefined", () => {
         const project = makeProject("libertyProject:maven:container");
-        project.isDevMode = false;
         assert.equal(filterProjects([project], "liberty.dev.start.container").length, 1);
     });
 
-    it("excludes container projects where isDevMode is true", () => {
+    it("excludes container projects where state is defined", () => {
         const project = makeProject("libertyProject:maven:container");
-        project.isDevMode = true;
+        project.setState("started");
         assert.equal(filterProjects([project], "liberty.dev.start.container").length, 0);
     });
 
-    it("excludes non-container projects regardless of isDevMode", () => {
+    it("excludes non-container projects regardless of state", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = false;
         assert.equal(filterProjects([project], "liberty.dev.start.container").length, 0);
     });
 });
 
 describe("filterProjects - liberty.dev.start", () => {
-    it("includes projects where isDevMode is false", () => {
+    it("includes projects where state is undefined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = false;
         const result = filterProjects([project], "liberty.dev.start");
         assert.equal(result.length, 1);
     });
 
-    it("excludes projects where isDevMode is true", () => {
+    it("excludes projects where state is defined", () => {
         const project = makeProject("libertyProject:maven");
-        project.isDevMode = true;
+        project.setState("started");
         const result = filterProjects([project], "liberty.dev.start");
         assert.equal(result.length, 0);
     });

--- a/src/test/unit/manualAdd.test.ts
+++ b/src/test/unit/manualAdd.test.ts
@@ -37,7 +37,7 @@ function makeProject(buildFilePath: string, type: string): LibertyProject {
         path.basename(path.dirname(buildFilePath)),
         vscode.TreeItemCollapsibleState.None,
         buildFilePath,
-        "start",
+        undefined,
         type,
         undefined,
         undefined,

--- a/src/util/helperUtil.ts
+++ b/src/util/helperUtil.ts
@@ -6,7 +6,7 @@
 import { DashboardData } from "./../liberty/dashboard";
 import * as fs from "fs";
 import * as vscode from "vscode";
-import { LibertyProject } from "./../liberty/libertyProject";
+import { LibertyProject, DevModeState } from "./../liberty/libertyProject";
 import {
 	LIBERTY_DASHBOARD_WORKSPACE_STORAGE_KEY, isMaven, isGradle, isContainer, isLibertyProject, isAggregator,
 	CMD_START, CMD_CUSTOM, CMD_START_CONTAINER, CMD_STOP, CMD_RUN_TESTS, CMD_DEBUG,
@@ -52,8 +52,8 @@ export function devModeRequirement(command: string): boolean | undefined {
 	}
 }
 
-export function computeContextValue(base: string, state: import("../liberty/libertyProject").DevModeState | undefined): string {
-	if (state === "started" && !base.includes(":aggregator")) {
+export function computeContextValue(base: string, state: DevModeState | undefined): string {
+	if (state === DevModeState.Running && !base.includes(":aggregator")) {
 		return `${base}:running`;
 	}
 	return base;

--- a/src/util/helperUtil.ts
+++ b/src/util/helperUtil.ts
@@ -52,8 +52,8 @@ export function devModeRequirement(command: string): boolean | undefined {
 	}
 }
 
-export function computeContextValue(base: string, isDevMode: boolean): string {
-	if (isDevMode && !base.includes(":aggregator")) {
+export function computeContextValue(base: string, state: import("../liberty/libertyProject").DevModeState | undefined): string {
+	if (state === "started" && !base.includes(":aggregator")) {
 		return `${base}:running`;
 	}
 	return base;
@@ -76,13 +76,13 @@ export function filterProjects(projects: LibertyProject[], command: string): Lib
 		switch (command) {
 			case CMD_START:
 			case CMD_CUSTOM:
-				return !isAggregator(cv) && !project.isDevMode;
+				return !isAggregator(cv) && project.state === undefined;
 			case CMD_START_CONTAINER:
-				return isContainer(cv) && !project.isDevMode;
+				return isContainer(cv) && project.state === undefined;
 			case CMD_STOP:
 			case CMD_RUN_TESTS:
 			case CMD_DEBUG:
-				return !isAggregator(cv) && project.isDevMode;
+				return !isAggregator(cv) && project.state !== undefined;
 			case "failsafe":
 			case "surefire":
 				return isMaven(cv) && !isAggregator(cv);


### PR DESCRIPTION
## Context
Adds POC for #521 

## Summary of changes

| file | change |
| --- | --- |
| `package(-lock).json` | Updated to version >1.93 for shell integration |
| `devCommand.ts` | 5 second timeout for shell integration, otherwise default to terminal check for server status. Add the `Starting...` and `Stopping...` statuses |
| `libertyProject.ts` | Add per-project terminal listeners to track status |
| `projectDiscovery.ts` | Now that start is a valid status, projects by default have an undefined state |
| `projectRegistery.ts` | Creates the listener that gets cleaned up upon terminal closure/stops |
| `projectTreeProvider.ts` | Visual indicate the statuses: Green for running and yellow for transition states. Additionally, aggregators need updates |

## Video Demo

https://github.com/user-attachments/assets/d20faaf3-5826-439e-841d-1a36c85e1d00



