### PR TITLE
Update custom parameters selection UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"preview": false,
 	"license": "EPL-2.0",
 	"engines": {
-		"vscode": ">=1.75.0"
+		"vscode": ">=1.76.0"
 	},
 	"categories": [
 		"Programming Languages"
@@ -262,7 +262,7 @@
 		"@types/node": "20.0.0",
 		"@types/selenium-webdriver": "4.1.22",
 		"@types/sinon": "^21.0.1",
-		"@types/vscode": "1.42.0",
+		"@types/vscode": "1.76.0",
 		"@typescript-eslint/eslint-plugin": "8.0.0",
 		"@typescript-eslint/parser": "8.0.0",
 		"@vscode/test-electron": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
 		"@types/node": "20.0.0",
 		"@types/selenium-webdriver": "4.1.22",
 		"@types/sinon": "^21.0.1",
-		"@types/vscode": "1.42.0",
+		"@types/vscode": "1.75.0",
 		"@typescript-eslint/eslint-plugin": "8.0.0",
 		"@typescript-eslint/parser": "8.0.0",
 		"@vscode/test-electron": "2.4.0",

--- a/src/liberty/dashboard.ts
+++ b/src/liberty/dashboard.ts
@@ -35,6 +35,12 @@ export class DashboardData {
     }
   }
 
+  public removeStartCmdParam(cmdParam: ProjectStartCmdParam): void {
+    this.lastUsedStartParams = this.lastUsedStartParams.filter(
+      element => !(element.path === cmdParam.path && element.param === cmdParam.param)
+    );
+  }
+
   public removeProject(path: string): void {
     this.projects = this.projects.filter(function (baseLibertyProject) {
       return baseLibertyProject.path !== path;

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -25,6 +25,7 @@ class LibertyProjectQuickPickItem implements QuickPickItem {
     label: string;
     detail: string;
     description: string | undefined;
+    alwaysShow?: boolean | undefined;
 
     constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject, itemDescription?: string) {
         this.label = itemLabel;
@@ -320,54 +321,71 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
         const projectProvider: ProjectProvider = ProjectProvider.getInstance();
         const dashboardData: DashboardData = helperUtil.getStorageData(projectProvider.getContext());
         const history = dashboardData.lastUsedStartParams.filter(element => element.path === libProject.getPath());
-        if (history.length === 0) {
-            //no history, show input.
-            await customDevMode(libProject);
-        } else {
-            // show history
-            // first item is the default custom command with no params
-            const items: LibertyProjectQuickPickItem[] = [];
-            const qpItem = new LibertyProjectQuickPickItem(" ",
-                "", libProject, localize("new.liberty.dev.with.custom.params"));
-            items.push(qpItem);
 
-            for (let index = 0; index < history.length; index++) {
-                const item = history[index];
-                const qpItem = new LibertyProjectQuickPickItem(item.param,
-                    item.path, libProject);
-                items.push(qpItem);
-            }
-            const qp = vscode.window.createQuickPick<LibertyProjectQuickPickItem>();
-            qp.items = items;
-            qp.keepScrollPosition = true;
-            qp.onDidChangeValue(() => {
-                let validationMessage = "";
-                if (qp.value && qp.value.trim().length > 0 && !qp.value.trim().startsWith("-")) {
-                    validationMessage = localize("params.must.start.with.dash");
-                }
-                qp.items[0].label = qp.value.trim();
-                qp.items[0].detail = localize("new.liberty.dev.with.custom.params");
-                qp.items[0].description = validationMessage;
-                qp.items = qp.items;
-            });
-            qp.onDidAccept(() => {
-                const selection = qp.selectedItems[0];
-                if (!selection) {
-                    qp.dispose();
-                    return;
-                }
-                if (selection.detail != localize("new.liberty.dev.with.custom.params") && selection.description != localize("new.liberty.dev.with.custom.params")) {
+        let placeHolderStr = "";
+        let promptString = localize("specify.custom.parms.maven");
+        if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
+            placeHolderStr = "e.g. -DhotTests=true";
+        } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
+            placeHolderStr = "e.g. --hotTests";
+            promptString = localize("specify.custom.parms.gradle");
+        }
+
+        // show history
+        const items: LibertyProjectQuickPickItem[] = [];
+        for (let index = 0; index < history.length; index++) {
+            const item = history[index];
+            const qpItem = new LibertyProjectQuickPickItem(item.param,
+                item.path, libProject);
+            items.push(qpItem);
+        }
+        const qp = vscode.window.createQuickPick<LibertyProjectQuickPickItem>();
+        qp.title = promptString;
+        qp.placeholder = placeHolderStr;
+        qp.items = items;
+        qp.keepScrollPosition = true;
+        qp.activeItems = [];
+        qp.show();
+        const disposables: vscode.Disposable[] = [];
+        try {
+            const params = await new Promise<string | void>(resolve => {
+                disposables.push(qp.onDidChangeValue(value => {
+                    if (value.trimStart()[0] === "-") {
+                        qp.items = [];
+                    } else {
+                        qp.items = items;
+                    }
+                }));
+                disposables.push(qp.onDidAccept(() => {
+                    const selection = qp.selectedItems[0];
+                    if (!selection) {
+                        if (qp.value.trimStart()[0] === "-") {
+                            resolve(qp.value);
+                            return;
+                        }
+                        qp.items = [{
+                            label: " ",
+                            project: undefined,
+                            description: localize("params.must.start.with.dash"),
+                            detail: "",
+                            alwaysShow: true,
+                        }];
+                        qp.activeItems = [];
+                        return;
+                    }
+                    if (selection.detail === localize("params.must.start.with.dash")) {
+                        return;
+                    }
                     qp.value = selection.label;
-                    return;
-                }
-                if (qp.value && qp.value.trim().length > 0 && !qp.value.trim().startsWith("-")) {
-                    return;
-                }
-                qp.dispose();
-                customDevMode(selection.project, qp.value.trim());
+                    qp.selectedItems = [];
+                }));
+                disposables.push(qp.onDidHide(() => resolve()));
             });
-            qp.onDidHide(() => qp.dispose());
-            qp.show();
+            if (params) {
+                customDevMode(libProject, params);
+            }
+        } finally {
+            disposables.forEach(d => d.dispose())
         }
 
     } else if (ProjectProvider.getInstance()) {
@@ -382,7 +400,7 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
 
 // custom start dev mode command
 export async function customDevMode(libProject?: LibertyProject | undefined, params?: string | undefined): Promise<void> {
-    const _customParameters = (params === undefined) ? "" : params.trim();
+    const customCommand = (params === undefined) ? "" : params.trim();
     if (libProject !== undefined) {
         let terminal = libProject.getTerminal();
         if (terminal === undefined) {
@@ -393,55 +411,21 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             terminal.show();
             libProject.setTerminal(terminal);
 
-            /*
-            let placeHolderStr = "";
-            let promptString = localize("specify.custom.parms.maven");
-            if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                placeHolderStr = "e.g. -DhotTests=true";
-            } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                placeHolderStr = "e.g. --hotTests";
-                promptString = localize("specify.custom.parms.gradle");
+            // save command
+            if ( customCommand.length > 0 ) {
+                const projectStartCmdParam: ProjectStartCmdParam = new ProjectStartCmdParam(libProject.getPath(), customCommand);
+                const projectProvider: ProjectProvider = ProjectProvider.getInstance();
+                const dashboardData: DashboardData = helperUtil.getStorageData(projectProvider.getContext());
+                dashboardData.addStartCmdParams(projectStartCmdParam);
+                await helperUtil.saveStorageData(projectProvider.getContext(), dashboardData);
             }
 
-            // set focus on the Inputbox
-            await vscode.commands.executeCommand('workbench.action.focusNextGroup');
-
-            // prompt for custom command
-            let customCommand: string | undefined = await vscode.window.showInputBox(Object.assign({
-                validateInput: (value: string) => {
-                    if (value && value.trim().length > 0 && !value.trim().startsWith("-")) {
-                        return localize("params.must.start.with.dash");
-                    }
-                    return null;
-                },
-            },
-                {
-                    placeHolder: placeHolderStr,
-                    prompt: promptString,
-                    ignoreFocusOut: true,
-                    value: _customParameters
-                },
-            ));
-            */
-           let customCommand = _customParameters;
-            if (customCommand !== undefined) {
-                // save command
-                customCommand = customCommand.trim();
-                if ( customCommand.length > 0 ) {
-                    const projectStartCmdParam: ProjectStartCmdParam = new ProjectStartCmdParam(libProject.getPath(), customCommand);
-                    const projectProvider: ProjectProvider = ProjectProvider.getInstance();
-                    const dashboardData: DashboardData = helperUtil.getStorageData(projectProvider.getContext());
-                    dashboardData.addStartCmdParams(projectStartCmdParam);
-                    await helperUtil.saveStorageData(projectProvider.getContext(), dashboardData);
-                }
-
-                if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
-                    const cmd = await getCommandForMaven(libProject.getPath(), "io.openliberty.tools:liberty-maven-plugin:dev", libProject.getTerminalType(), customCommand);
-                    terminal.sendText(cmd);
-                } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
-                    const cmd = await getCommandForGradle(libProject.getPath(), "libertyDev", libProject.getTerminalType(), customCommand);
-                    terminal.sendText(cmd);
-                }
+            if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
+                const cmd = await getCommandForMaven(libProject.getPath(), "io.openliberty.tools:liberty-maven-plugin:dev", libProject.getTerminalType(), customCommand);
+                terminal.sendText(cmd);
+            } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT || libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER) {
+                const cmd = await getCommandForGradle(libProject.getPath(), "libertyDev", libProject.getTerminalType(), customCommand);
+                terminal.sendText(cmd);
             }
         }
     } else if (ProjectProvider.getInstance()) {

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -24,11 +24,13 @@ class LibertyProjectQuickPickItem implements QuickPickItem {
     project: LibertyProject | undefined;
     label: string;
     detail: string;
+    description: string | undefined;
 
-    constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject) {
+    constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject, itemDescription?: string) {
         this.label = itemLabel;
         this.detail = itemDetail;
         this.project = itemProject;
+        this.description = itemDescription;
     }
 }
 
@@ -324,7 +326,7 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
             // first item is the default custom command with no params
             const items: LibertyProjectQuickPickItem[] = [];
             const qpItem = new LibertyProjectQuickPickItem(" ",
-                history[0].path, libProject);
+                "", libProject, localize("new.liberty.dev.with.custom.params"));
             items.push(qpItem);
 
             for (let index = 0; index < history.length; index++) {

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -52,7 +52,9 @@ function showProjects(command: string, callback: Function, reportType?: string):
                 item.path, item);
             items.push(qpItem);
         }
-        vscode.window.showQuickPick(items).then(selection => {
+        vscode.window.showQuickPick(items, {
+            placeHolder: localize("select.liberty.project"),
+        }).then(selection => {
             if (!selection) {
                 return;
             }

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -24,15 +24,14 @@ class LibertyProjectQuickPickItem implements QuickPickItem {
     project: LibertyProject | undefined;
     label: string;
     detail: string;
-    description: string | undefined;
-    alwaysShow?: boolean | undefined;
+    description?: string;
+    alwaysShow?: boolean;
     buttons?: vscode.QuickInputButton[];
 
-    constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject, itemDescription?: string) {
+    constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject) {
         this.label = itemLabel;
         this.detail = itemDetail;
         this.project = itemProject;
-        this.description = itemDescription;
     }
 }
 
@@ -324,7 +323,7 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
         const history = dashboardData.lastUsedStartParams.filter(element => element.path === libProject.getPath());
 
         const deleteButton: vscode.QuickInputButton = {
-            iconPath: new vscode.ThemeIcon("trash"),
+            iconPath: new vscode.ThemeIcon("close"),
             tooltip: localize("delete.custom.params.from.history"),
         };
 
@@ -346,58 +345,67 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
             qpItem.buttons = [deleteButton];
             items.push(qpItem);
         }
+
+        // prompt for custom command
         const qp = vscode.window.createQuickPick<LibertyProjectQuickPickItem>();
-        qp.title = promptString;
-        qp.placeholder = placeHolderStr;
-        qp.items = items;
-        qp.keepScrollPosition = true;
-        qp.activeItems = [];
-        qp.show();
         const disposables: vscode.Disposable[] = [];
         try {
+            qp.title = promptString;
+            qp.placeholder = placeHolderStr;
+            qp.items = items;
+            qp.keepScrollPosition = true;
+            qp.show();
             const params = await new Promise<string | void>(resolve => {
                 disposables.push(qp.onDidChangeValue(value => {
-                    if (value.trimStart()[0] === "-") {
+                    // show history only if input doesn't look like parameters
+                    if (qp.value.trimStart().startsWith("-")) {
                         qp.items = [];
                     } else {
                         qp.items = items;
                     }
                 }));
                 disposables.push(qp.onDidAccept(() => {
-                    const selection = qp.selectedItems[0];
-                    if (!selection) {
-                        if (qp.value.trimStart()[0] === "-") {
-                            resolve(qp.value);
-                            return;
+                    if (qp.selectedItems.length > 0) {
+                        // history item selected, overwrite input with its params
+                        const selection = qp.selectedItems[0];
+                        if (selection.project) {
+                            qp.value = selection.label;
                         }
+                        qp.selectedItems = [];
+                    } else if (qp.value.trimStart().startsWith("-")) {
+                        // valid parameters, return params for custom dev mode
+                        resolve(qp.value);
+                    } else {
+                        // invalid parameters, show validation message
                         qp.items = [{
-                            label: " ",
                             project: undefined,
-                            description: localize("params.must.start.with.dash"),
+                            label: " ",
                             detail: "",
+                            description: localize("params.must.start.with.dash"),
                             alwaysShow: true,
                         }];
                         qp.activeItems = [];
-                        return;
                     }
-                    if (selection.detail === localize("params.must.start.with.dash")) {
-                        return;
-                    }
-                    qp.value = selection.label;
-                    qp.selectedItems = [];
                 }));
                 disposables.push(qp.onDidTriggerItemButton(async ({ item }) => {
+                    // delete button pressed, remove history item
                     dashboardData.removeStartCmdParam(new ProjectStartCmdParam(item.detail, item.label));
                     await helperUtil.saveStorageData(projectProvider.getContext(), dashboardData);
-                    qp.items = qp.items.filter(element => element !== item);
+                    items.splice(items.indexOf(item), 1);
+                    qp.items = items;
                 }));
-                disposables.push(qp.onDidHide(() => resolve()));
+                disposables.push(qp.onDidHide(() => {
+                    // return so the UI is disposed
+                    resolve();
+                }));
             });
-            if (params) {
+            if (params !== undefined) {
                 customDevMode(libProject, params);
             }
+
         } finally {
-            disposables.forEach(d => d.dispose())
+            disposables.forEach(d => d.dispose());
+            qp.dispose();
         }
 
     } else if (ProjectProvider.getInstance()) {

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -337,12 +337,37 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
                     item.path, libProject);
                 items.push(qpItem);
             }
-            vscode.window.showQuickPick(items).then(selection => {
+            const qp = vscode.window.createQuickPick<LibertyProjectQuickPickItem>();
+            qp.items = items;
+            qp.keepScrollPosition = true;
+            qp.onDidChangeValue(() => {
+                let validationMessage = "";
+                if (qp.value && qp.value.trim().length > 0 && !qp.value.trim().startsWith("-")) {
+                    validationMessage = localize("params.must.start.with.dash");
+                }
+                qp.items[0].label = qp.value.trim();
+                qp.items[0].detail = localize("new.liberty.dev.with.custom.params");
+                qp.items[0].description = validationMessage;
+                qp.items = qp.items;
+            });
+            qp.onDidAccept(() => {
+                const selection = qp.selectedItems[0];
                 if (!selection) {
+                    qp.dispose();
                     return;
                 }
-                customDevMode(selection.project, selection.label);
+                if (selection.detail != localize("new.liberty.dev.with.custom.params") && selection.description != localize("new.liberty.dev.with.custom.params")) {
+                    qp.value = selection.label;
+                    return;
+                }
+                if (qp.value && qp.value.trim().length > 0 && !qp.value.trim().startsWith("-")) {
+                    return;
+                }
+                qp.dispose();
+                customDevMode(selection.project, qp.value.trim());
             });
+            qp.onDidHide(() => qp.dispose());
+            qp.show();
         }
 
     } else if (ProjectProvider.getInstance()) {
@@ -368,6 +393,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             terminal.show();
             libProject.setTerminal(terminal);
 
+            /*
             let placeHolderStr = "";
             let promptString = localize("specify.custom.parms.maven");
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT || libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER) {
@@ -396,6 +422,8 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
                     value: _customParameters
                 },
             ));
+            */
+           let customCommand = _customParameters;
             if (customCommand !== undefined) {
                 // save command
                 customCommand = customCommand.trim();

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -24,6 +24,7 @@ class LibertyProjectQuickPickItem implements QuickPickItem {
     project: LibertyProject | undefined;
     label: string;
     detail: string;
+    buttons?: vscode.QuickInputButton[];
 
     constructor(itemLabel: string, itemDetail: string, itemProject?: LibertyProject) {
         this.label = itemLabel;
@@ -322,6 +323,10 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
         } else {
             // show history
             // first item is the default custom command with no params
+            const deleteButton: vscode.QuickInputButton = {
+                iconPath: new vscode.ThemeIcon("trash"),
+                tooltip: localize("delete.custom.params.from.history"),
+            };
             const items: LibertyProjectQuickPickItem[] = [];
             const qpItem = new LibertyProjectQuickPickItem(" ",
                 history[0].path, libProject);
@@ -331,14 +336,31 @@ export async function customDevModeWithHistory(libProject?: LibertyProject | und
                 const item = history[index];
                 const qpItem = new LibertyProjectQuickPickItem(item.param,
                     item.path, libProject);
+                qpItem.buttons = [deleteButton];
                 items.push(qpItem);
             }
-            vscode.window.showQuickPick(items).then(selection => {
+            const qp = vscode.window.createQuickPick<LibertyProjectQuickPickItem>();
+            qp.items = items;
+            qp.keepScrollPosition = true;
+            qp.onDidAccept(() => {
+                const selection = qp.selectedItems[0];
+                qp.dispose();
                 if (!selection) {
                     return;
                 }
                 customDevMode(selection.project, selection.label);
             });
+            qp.onDidTriggerItemButton(async ({ item }) => {
+                dashboardData.removeStartCmdParam(new ProjectStartCmdParam(item.detail, item.label));
+                await helperUtil.saveStorageData(projectProvider.getContext(), dashboardData);
+                qp.items = qp.items.filter(element => element !== item);
+                if (qp.items.length <= 1) {
+                    qp.dispose();
+                    customDevMode(libProject);
+                }
+            });
+            qp.onDidHide(() => qp.dispose());
+            qp.show();
         }
 
     } else if (ProjectProvider.getInstance()) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "stopping.liverty.dev.on": "Stopping Liberty dev mode on {0}.",
     "liberty.dev.not.started.on": "Liberty dev mode did not start on {0}.",
     "cannot.stop.liberty.dev.on.undefined": "Cannot stop Liberty dev mode on an undefined project.",
+    "delete.custom.params.from.history": "Remove parameters from history",
     "params.must.start.with.dash": "Parameters must start with -",
     "starting.liberty.dev.with.custom.param": "Starting Liberty dev mode with custom parameters on {0}.",
     "specify.custom.parms.maven": "Specify custom parameters for 'mvn liberty:dev' command.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "stopping.liverty.dev.on": "Stopping Liberty dev mode on {0}.",
     "liberty.dev.not.started.on": "Liberty dev mode did not start on {0}.",
     "cannot.stop.liberty.dev.on.undefined": "Cannot stop Liberty dev mode on an undefined project.",
+    "new.liberty.dev.with.custom.params": "New Liberty start command",
     "params.must.start.with.dash": "Parameters must start with -",
     "starting.liberty.dev.with.custom.param": "Starting Liberty dev mode with custom parameters on {0}.",
     "specify.custom.parms.maven": "Specify custom parameters for 'mvn liberty:dev' command.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,6 @@
     "liberty.dev.not.started.on": "Liberty dev mode did not start on {0}.",
     "cannot.stop.liberty.dev.on.undefined": "Cannot stop Liberty dev mode on an undefined project.",
     "select.liberty.project": "Select project...",
-    "new.liberty.dev.with.custom.params": "New Liberty start command",
     "delete.custom.params.from.history": "Remove parameters from history",
     "params.must.start.with.dash": "Parameters must start with -",
     "starting.liberty.dev.with.custom.param": "Starting Liberty dev mode with custom parameters on {0}.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "stopping.liverty.dev.on": "Stopping Liberty dev mode on {0}.",
     "liberty.dev.not.started.on": "Liberty dev mode did not start on {0}.",
     "cannot.stop.liberty.dev.on.undefined": "Cannot stop Liberty dev mode on an undefined project.",
+    "select.liberty.project": "Select project...",
     "new.liberty.dev.with.custom.params": "New Liberty start command",
     "params.must.start.with.dash": "Parameters must start with -",
     "starting.liberty.dev.with.custom.param": "Starting Liberty dev mode with custom parameters on {0}.",


### PR DESCRIPTION
Fixes GH-153

<details><summary>Screenshots:</summary>

### Current UI

First, select a project:
<img width="537" height="95" alt="image" src="https://github.com/user-attachments/assets/230e823f-8b25-4e9e-9cb0-c34203c7012b" />

If there's history, the user can filter and choose an item:
<img width="533" height="271" alt="image" src="https://github.com/user-attachments/assets/e63879bd-06f6-4d5c-a3c1-d11f04b9b936" />
<img width="536" height="140" alt="image" src="https://github.com/user-attachments/assets/10049039-8f53-42e0-bfdc-eb6c464a41b8" />

In a third step, the user can edit the chosen params:
<img width="536" height="91" alt="image" src="https://github.com/user-attachments/assets/fd5c6493-bd08-464a-b7e0-5fe305d411f1" />

Invalid params give a warning:
<img width="536" height="72" alt="image" src="https://github.com/user-attachments/assets/b4fa211c-2726-4a0d-a763-cc224550cfba" />

### This PR

First, select a project:
<img width="532" height="95" alt="image" src="https://github.com/user-attachments/assets/c0538fc0-4cf5-4ab6-a961-ce5613dafd58" />

The user can type in params directly, or filter their history:
<img width="536" height="255" alt="image" src="https://github.com/user-attachments/assets/6ea2c133-df43-4980-a16e-b0a12130789f" />
<img width="533" height="162" alt="image" src="https://github.com/user-attachments/assets/50f37896-ff9e-4a35-b914-54d49d6332a2" />

Choosing a history item only copies the params to the input, allowing the user to edit it:
<img width="534" height="76" alt="image" src="https://github.com/user-attachments/assets/8c50c2a8-843d-4ed8-a97c-d9ee34df4c3b" />

Invalid params give a warning when enter is pressed (using a unselectable quick input item):
<img width="536" height="98" alt="image" src="https://github.com/user-attachments/assets/c056324b-0372-4da0-9e8b-5f533e5f27c9" />

</details>