### PR TITLE
Add 'Start in debug mode' command (liberty.dev.start.debug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"workspaceContains:**/pom.xml",
 		"workspaceContains:**/build.gradle",
 		"onCommand:liberty.dev.start",
+		"onCommand:liberty.dev.start.debug",
 		"onCommand:liberty.dev.stop",
 		"onCommand:liberty.dev.custom",
 		"onCommand:liberty.dev.run.tests",
@@ -87,6 +88,11 @@
 				"command": "liberty.dev.start",
 				"category": "Liberty",
 				"title": "%commands.title.start%"
+			},
+			{
+				"command": "liberty.dev.start.debug",
+				"category": "Liberty",
+				"title": "%commands.title.start.debug%"
 			},
 			{
 				"command": "liberty.dev.debug",
@@ -174,6 +180,11 @@
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
+					"group": "libertyCore@1"
+				},
+				{
+					"command": "liberty.dev.start.debug",
 					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject || viewItem == libertyMavenProjectContainer || viewItem == libertyGradleProjectContainer",
 					"group": "libertyCore@1"
 				},

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
     "views.explorer.name": "Liberty Tools",
     "commands.title.refresh": "Refresh projects",
     "commands.title.start": "Start",
+    "commands.title.start.debug": "Start in debug mode",
     "commands.title.debug": "Attach debugger",
     "commands.title.stop": "Stop",
     "commands.title.start.custom": "Start...",

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -18,6 +18,7 @@ export const LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION = "3.1.0";
 export const LIBERTY_SERVER_ENV_PORT_REGEX = /^WLP_DEBUG_ADDRESS=([\d]+)$/;
 export const COMMAND_AND_PROJECT_TYPE_MAP: { [command: string]: string[] } = {
     "liberty.dev.start": [LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
+    "liberty.dev.start.debug": [LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
     "liberty.dev.stop":[LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
     "liberty.dev.custom":[LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT, LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
     "liberty.dev.start.container":[ LIBERTY_MAVEN_PROJECT_CONTAINER, LIBERTY_GRADLE_PROJECT_CONTAINER],
@@ -33,6 +34,7 @@ export const UNTITLED_WORKSPACE="Untitled (Workspace)";
 COMMAND_TITLES.set(localize("hotkey.commands.title.refresh"), "liberty.explorer.refresh");
 
 COMMAND_TITLES.set(localize("hotkey.commands.title.start"), "liberty.dev.start");
+COMMAND_TITLES.set(localize("hotkey.commands.title.start.debug"), "liberty.dev.start.debug");
 COMMAND_TITLES.set(localize("hotkey.commands.title.start.custom"), "liberty.dev.custom");
 COMMAND_TITLES.set(localize("hotkey.commands.title.start.in.container"), "liberty.dev.start.container");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,6 +133,9 @@ function registerCommands(context: ExtensionContext) {
         vscode.commands.registerCommand("liberty.dev.start", (libProject?: LibertyProject) => devCommands.startDevMode(libProject)),
     );
     context.subscriptions.push(
+        vscode.commands.registerCommand("liberty.dev.start.debug", (libProject?: LibertyProject) => devCommands.startDevModeWithDebugger(libProject)),
+    );
+    context.subscriptions.push(
         vscode.commands.registerCommand("liberty.dev.debug", (libProject?: LibertyProject) => devCommands.attachDebugger(libProject)),
     );
     context.subscriptions.push(

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -122,6 +122,109 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
     }
 }
 
+export async function startDevModeWithDebugger(
+    libProject?: LibertyProject | undefined
+): Promise<void> {
+    if (libProject === undefined) {
+        if (ProjectProvider.getInstance()) {
+            showProjects("liberty.dev.start.debug", startDevModeWithDebugger);
+        } else {
+            vscode.window.showInformationMessage(
+                localize("cannot.start.liberty.dev.debug.undefined")
+            );
+        }
+        return;
+    }
+
+    // 1. Start dev mode with the debug flag
+    let terminal = libProject.getTerminal();
+    if (terminal === undefined) {
+        terminal = createTerminalforLiberty(libProject, terminal);
+    }
+    if (terminal === undefined) { return; }
+
+    terminal.show();
+    libProject.setTerminal(terminal);
+
+    const isMaven =
+        libProject.getContextValue() === LIBERTY_MAVEN_PROJECT ||
+        libProject.getContextValue() === LIBERTY_MAVEN_PROJECT_CONTAINER;
+    const isGradle =
+        libProject.getContextValue() === LIBERTY_GRADLE_PROJECT ||
+        libProject.getContextValue() === LIBERTY_GRADLE_PROJECT_CONTAINER;
+
+    if (isMaven) {
+        const cmd = await getCommandForMaven(
+            libProject.getPath(),
+            "io.openliberty.tools:liberty-maven-plugin:dev",
+            libProject.getTerminalType(),
+            "-DlibertyDebugPort=7777"    // enable debug
+        );
+        terminal.sendText(cmd);
+    } else if (isGradle) {
+        const cmd = await getCommandForGradle(
+            libProject.getPath(),
+            "libertyDev",
+            libProject.getTerminalType(),
+            "--libertyDebugPort=7777"    // enable debug
+        );
+        terminal.sendText(cmd);
+    } else {
+        return;
+    }
+
+    // 2. Watch for server.env to change
+    const pathPrefix = isMaven ? "target" : "build";
+    const pattern = new vscode.RelativePattern(
+        Path.dirname(libProject.getPath()),
+        pathPrefix + "/**/server.env"
+    );
+
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+    const TIMEOUT_MS = 3 * 60 * 1000; // 3-minute safety timeout
+
+    const tryAttach = async (uri: vscode.Uri) => {
+        const lines = (await fse.readFile(uri.fsPath, "utf8")).split("\n");
+        let port = "";
+        for (const line of lines) {
+            const match = LIBERTY_SERVER_ENV_PORT_REGEX.exec(line);
+            if (match) { port = match[1]; break; }
+        }
+        if (port === "") { return; }          // port not written yet, wait for next change
+
+        // delete server.env watcher
+        watcher.dispose();
+        clearTimeout(timer);
+
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+            vscode.Uri.file(libProject.getPath())
+        );
+        vscode.debug.startDebugging(workspaceFolder, {
+            type: "java",
+            name: localize("liberty.dev.debug.label", Path.dirname(libProject.getPath())),
+            request: "attach",
+            hostName: "localhost",
+            port,
+            cwd: Path.dirname(libProject.getPath()),
+            projectName: libProject.getLabel(),
+        }).then(() => {}, err => {
+            vscode.window.showErrorMessage(
+                localize("liberty.dev.attach.debugger.failed.with.error", err.message)
+            );
+        });
+    };
+
+    watcher.onDidCreate(tryAttach);
+    watcher.onDidChange(tryAttach);
+
+    const timer = setTimeout(() => {
+        watcher.dispose();
+        vscode.window.showWarningMessage(
+            localize("liberty.dev.debug.attach.timeout", libProject.getLabel())
+        );
+    }, TIMEOUT_MS);
+}
+
 
 export async function removeProject(): Promise<void> {
     const projectProvider: ProjectProvider = ProjectProvider.getInstance();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
     "check.java.runtime.failed.locate": "Java runtime could not be located.",
     "hotkey.commands.title.refresh": "Liberty: Refresh projects",
     "hotkey.commands.title.start": "Liberty: Start",
+    "hotkey.commands.title.start.debug": "Liberty: Start in debug mode",
     "hotkey.commands.title.debug": "Liberty: Attach debugger",
     "hotkey.commands.title.stop": "Liberty: Stop",
     "hotkey.commands.title.start.custom": "Liberty: Start...",
@@ -75,6 +76,8 @@
     "hotkey.commands.title.remove.project": "Liberty: Remove Project from Liberty Tools",
     "hotkey.commands.title.show.commands": "Liberty: Show Liberty commands",
     "workspace.not.saved.projects.may.not.persist": "Save the workspace first. Projects that you manually add to Liberty Tools might not persist in the next VS Code session if you don't save the workspace before you add the project.",
+    "cannot.start.liberty.dev.debug.undefined": "Cannot start Liberty dev mode in debug on an undefined project.",
+    "liberty.dev.debug.attach.timeout": "Liberty dev mode started but the debugger could not attach within the timeout period for {0}. Use 'Liberty: Attach debugger' to attach manually.",
     "redhat.java.version.incompatible": "The installed 'Language Support for Java' extension v{0} is not compatible with this version of Liberty Tools. Use 'Language Support for Java' v{1} or earlier for full support.",
     "redhat.java.version.incompatible.install": "Install Supported Version",
     "redhat.java.version.incompatible.open": "View in Marketplace"


### PR DESCRIPTION
Fixes #116 

Adds a new "Start in debug mode" command (`liberty.dev.start.debug`) that starts Liberty dev mode with the debugger enabled and automatically attaches the Java debugger/

## How it works
1. Starts Liberty dev mode with `-DlibertyDebugPort=7777` (Maven) or `--libertyDebugPort=7777` (Gradle)
2. Liberty may reassign the port if 7777 is unavailable, the actual port gets written to `server.env` as `WLP_DEBUG_ADDRESS=<port>`
3. A `FileSystemWatcher` on `target/**/server.env` / `build/**/server.env` fires when the file is created or updated and reads the real port
4. The Java debugger is automatically attached to that port via `vscode.debug.startDebugging`
5. A 3-minute safety timeout disposes the watcher and shows a warning if the server never starts, prompting the user to use "Attach debugger" manually

## Changes
- `package.json`: command declaration, `onCommand` activation event, context menu entry
- `package.nls.json`: title string "Start in debug mode"
- `src/definitions/constants.ts`:  added to `COMMAND_AND_PROJECT_TYPE_MAP` and `COMMAND_TITLES`
- `src/extension.ts`:  registers `liberty.dev.start.debug` → `startDevModeWithDebugger()`
- `src/liberty/devCommands.ts`:  new `startDevModeWithDebugger()` implementation
- `src/locales/en.json`:  new i18n strings