### PR TITLE
java home doc and deprecation update

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -87,13 +87,15 @@ When you start a Liberty project, Liberty Tools sets `JAVA_HOME` in the terminal
 
 1. `liberty.java.home` in settings.json — manual override, takes priority over everything else.
 2. `java.configuration.runtimes` in the project's `.vscode/settings.json` (entry marked `default: true` is preferred).
-3. `java.jdt.ls.java.home`, `xml.java.home`, `java.import.maven.java.home`, or `java.import.gradle.java.home` in settings.json.
+3. `java.jdt.ls.java.home`, `xml.java.home`, `java.import.maven.java.home`, `java.import.gradle.java.home`, or `java.home` in settings.json.
 4. `JAVA_HOME` or `JDK_HOME` as system environment variables.
 5. JDKs discovered on the system path.
 
 If no JDK is found, the terminal opens without a `JAVA_HOME` prefix and uses whatever `java` is available on the system PATH.
 
 Note: The JDK used for the dev mode terminal is resolved independently from the JDK used to run the language servers. A project can run dev mode on Java 17 while the language servers run on Java 21.
+
+Note: The `liberty.terminal.useJavaHome` setting is deprecated and no longer has any effect. If you previously used it to point Liberty terminals at a specific JDK via `java.home`, you can now set `liberty.java.home` directly to the JDK path, or leave it unset to let Liberty Tools detect the JDK automatically from the sources listed above.
 
 ### Terminal shell support
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // VS Code setting so the next findFirstValid() call picks up the new value.
     context.subscriptions.push(JavaSelector.getInstance().watchConfigChanges());
 
+    // Warn users who still have the deprecated liberty.terminal.useJavaHome setting enabled.
+    const useJavaHome = workspace.getConfiguration("liberty").get<boolean>("terminal.useJavaHome");
+    if (useJavaHome) {
+        window.showWarningMessage(
+            "The 'liberty.terminal.useJavaHome' setting is deprecated and no longer has any effect. " +
+            "Set 'liberty.java.home' to the JDK path you want Liberty dev mode to use, or remove the setting to use automatic JDK detection."
+        );
+    }
+
     resolveLclsRequirements(api).then().catch((error => {
         window.showErrorMessage(error.message, error.label).then((selection) => {
             if (error.label && error.label === selection && error.openUrl) {


### PR DESCRIPTION
Relies on #652 
Closes #331 

The liberty.terminal.useJavaHome + java.home opt-in mechanism from the old code has been superseded by the per-project Java resolution work in #652. java.home is now automatically checked as part of the terminal JDK detection chain — no boolean gate needed.

## Changes:

1. Added java.home to the terminal JDK priority list in the user guide (it was already supported but undocumented)
2. Add deprecation note in the user guide for liberty.terminal.useJavaHome, pointing users to liberty.java.home or automatic detection
3. Show a runtime warning at activation if liberty.terminal.useJavaHome: true is still set, so existing users get a clear migration message