### PR TITLE
Updates for Gradle commands, server status, terminal delay fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
-					"when": "viewItem =~ /^libertyProject(?!.*:running)(?!.*:aggregator)/ || viewItem =~ /^libertyProject.*:aggregator/",
+					"when": "viewItem =~ /^libertyProject(?!.*:running)(?!.*:server-started)(?!.*:aggregator)/ || viewItem =~ /^libertyProject.*:aggregator/",
 					"group": "libertyCore@1"
 				},
 				{
@@ -284,12 +284,12 @@
 				},
 				{
 					"command": "liberty.dev.stop",
-					"when": "viewItem =~ /^libertyProject.*:running/ || viewItem =~ /^libertyProject.*:aggregator/",
+					"when": "viewItem =~ /^libertyProject.*:running/ || viewItem =~ /^libertyProject.*:server-started/ || viewItem =~ /^libertyProject.*:aggregator/",
 					"group": "libertyCore@3"
 				},
 				{
 					"command": "liberty.dev.custom",
-					"when": "viewItem =~ /^libertyProject(?!.*:running)(?!.*:aggregator)/ || viewItem =~ /^libertyProject.*:aggregator/",
+					"when": "viewItem =~ /^libertyProject(?!.*:running)(?!.*:server-started)(?!.*:aggregator)/ || viewItem =~ /^libertyProject.*:aggregator/",
 					"group": "libertyCore@2"
 				},
 				{

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -171,7 +171,7 @@ async function sendDevModeCommand(
     gradleTask: string,
     customCommand?: string,
     javaHome?: string
-): Promise<boolean> {
+): Promise<void> {
     let cmd: string | undefined;
     if (isMaven(project.getContextValue())) {
         const pomPath = project.parent ? project.parent.getPath() : project.getPath();
@@ -182,18 +182,33 @@ async function sendDevModeCommand(
         const projectName = project.parent ? project.artifactId : undefined;
         cmd = await getCommandForGradle(buildGradlePath, gradleTask, project.getTerminalType(), customCommand, projectName);
     }
-    if (cmd === undefined) { return false; }
+    if (cmd === undefined) { return; }
     if (javaHome) { cmd = prependJavaHome(cmd, javaHome); }
-    const si = terminal.shellIntegration ?? await waitForShellIntegration(terminal);
-    if (si) {
-        console.log(`[sendDevModeCommand] using shellIntegration.executeCommand for ${project.label}`);
-        si.executeCommand(cmd);
-        return true;
-    } else {
-        console.log(`[sendDevModeCommand] shellIntegration not ready after timeout, falling back to sendText for ${project.label}`);
-        terminal.sendText(cmd);
-        return false;
+
+    // If shell integration is already available (e.g. reused terminal) use it immediately.
+    if (terminal.shellIntegration) {
+        console.log(`[sendDevModeCommand] shellIntegration already available, using executeCommand for ${project.label}`);
+        terminal.shellIntegration.executeCommand(cmd);
+        return;
     }
+
+    // Shell integration is not yet ready (fresh terminal — shell rc scripts still loading).
+    // Send the command immediately via sendText so there is no visible delay, then wait
+    // for shell integration in the background. The onDidStartTerminalShellExecution listener
+    // in ProjectRegistry will attach the output monitor once the shell is ready.
+    console.log(`[sendDevModeCommand] shell integration not ready, sending immediately via sendText for ${project.label}`);
+    terminal.sendText(cmd);
+
+    // Background: wait for shell integration so the next command on this terminal
+    // (e.g. run tests) can use executeCommand. Log only — no await, no blocking.
+    waitForShellIntegration(terminal).then(si => {
+        if (si) {
+            console.log(`[sendDevModeCommand] shell integration arrived for ${project.label}`);
+        } else {
+            console.warn(`[sendDevModeCommand] shell integration never arrived for ${project.label}`);
+        }
+    });
+
 }
 
 export async function startDevMode(libProject?: LibertyProject | undefined, treeView?: vscode.TreeView<LibertyProject>): Promise<void> {
@@ -214,8 +229,8 @@ export async function startDevMode(libProject?: LibertyProject | undefined, tree
         console.log(localize("starting.liberty.dev.on", targetProject.getLabel()));
         const result = await ensureTerminal(targetProject);
         if (result !== undefined) {
-            const tracked = await sendDevModeCommand(result.terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, undefined, result.javaHome);
-            targetProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
+            await sendDevModeCommand(result.terminal, targetProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, undefined, result.javaHome);
+            targetProject.setState(DevModeState.Starting);
             projectProvider.notifyDevModeChanged(targetProject);
         }
     }));
@@ -508,8 +523,8 @@ export async function customDevMode(libProject?: LibertyProject | undefined, par
             await helperUtil.saveStorageData(registry.getContext(), dashboardData);
         }
 
-        const tracked = await sendDevModeCommand(result.terminal, libProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, customParameters, result.javaHome);
-        libProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
+        await sendDevModeCommand(result.terminal, libProject, MAVEN_GOAL_DEV, GRADLE_TASK_DEV, customParameters, result.javaHome);
+        libProject.setState(DevModeState.Starting);
         projectProvider.notifyDevModeChanged(libProject);
     }
 }
@@ -531,8 +546,8 @@ export async function startContainerDevMode(libProject?: LibertyProject | undefi
     await Promise.all(targetProjects.map(async targetProject => {
         const result = await ensureTerminal(targetProject);
         if (result !== undefined) {
-            const tracked = await sendDevModeCommand(result.terminal, targetProject, MAVEN_GOAL_DEVC, GRADLE_TASK_DEVC, undefined, result.javaHome);
-            targetProject.setState(tracked ? DevModeState.Starting : DevModeState.Running);
+            await sendDevModeCommand(result.terminal, targetProject, MAVEN_GOAL_DEVC, GRADLE_TASK_DEVC, undefined, result.javaHome);
+            targetProject.setState(DevModeState.Starting);
             projectProvider.notifyDevModeChanged(targetProject);
         }
     }));

--- a/src/liberty/devCommands.ts
+++ b/src/liberty/devCommands.ts
@@ -178,7 +178,9 @@ async function sendDevModeCommand(
         const artifactId = project.parent ? project.artifactId : undefined;
         cmd = await getCommandForMaven(pomPath, mavenGoal, project.getTerminalType(), customCommand, artifactId);
     } else if (isGradle(project.getContextValue())) {
-        cmd = await getCommandForGradle(project.getPath(), gradleTask, project.getTerminalType(), customCommand);
+        const buildGradlePath = project.parent ? project.parent.getPath() : project.getPath();
+        const projectName = project.parent ? project.artifactId : undefined;
+        cmd = await getCommandForGradle(buildGradlePath, gradleTask, project.getTerminalType(), customCommand, projectName);
     }
     if (cmd === undefined) { return false; }
     if (javaHome) { cmd = prependJavaHome(cmd, javaHome); }

--- a/src/liberty/libertyProject.ts
+++ b/src/liberty/libertyProject.ts
@@ -16,16 +16,22 @@ const OL_LOGO_ICON = "ol_logo.png";
 
 export enum DevModeState {
 	Starting = "starting",
+	ServerStarted = "server-started",
 	Running = "running",
 	Stopping = "stopping",
 }
 
 /**
- * CWWKF0011I = server ready (starting → started)
- * CWWKE0036I = server stopped (stopping → cleared)
+ * CWWKF0011I = Liberty server ready      (Starting → ServerStarted)
+ * CWWKZ0001I = application deployed      (ServerStarted → Running)
+ * CWWKE0036I = server stopped            (any → undefined)
  */
-export const LIBERTY_MSG_STARTED = "CWWKF0011I";
-export const LIBERTY_MSG_STOPPED = "CWWKE0036I";
+export const LIBERTY_MSG_SERVER_STARTED = "CWWKF0011I";
+export const LIBERTY_MSG_APP_STARTED    = "CWWKZ0001I";
+export const LIBERTY_MSG_STOPPED        = "CWWKE0036I";
+
+/** @deprecated Use LIBERTY_MSG_SERVER_STARTED */
+export const LIBERTY_MSG_STARTED = LIBERTY_MSG_SERVER_STARTED;
 
 export class LibertyProject extends vscode.TreeItem {
 	public parent?: LibertyProject;
@@ -156,7 +162,15 @@ export class LibertyProject extends vscode.TreeItem {
 		(async () => {
 			for await (const chunk of stream) {
 				if (disposed) { break; }
-				if (chunk.includes(LIBERTY_MSG_STARTED) && this.state === DevModeState.Starting) {
+				const serverUp = chunk.includes(LIBERTY_MSG_SERVER_STARTED);
+				const appUp    = chunk.includes(LIBERTY_MSG_APP_STARTED);
+				if ((serverUp || appUp) && this.state === DevModeState.Starting) {
+					// First signal — move to ServerStarted unless app is already confirmed
+					this.setState(appUp ? DevModeState.Running : DevModeState.ServerStarted);
+					onStateChange(this);
+					if (appUp) { vscode.window.showInformationMessage(`Liberty server started: ${this.label}`); }
+				} else if (appUp && this.state === DevModeState.ServerStarted) {
+					// Server was up, app now confirmed
 					this.setState(DevModeState.Running);
 					onStateChange(this);
 					vscode.window.showInformationMessage(`Liberty server started: ${this.label}`);

--- a/src/liberty/projectTreeProvider.ts
+++ b/src/liberty/projectTreeProvider.ts
@@ -32,6 +32,11 @@ export class LibertyDevDecorationProvider {
 					color: new vscode.ThemeColor("debugIcon.startForeground"),
 					tooltip: "Dev mode is running",
 				};
+			case "server-started":
+				return {
+					color: new vscode.ThemeColor("charts.yellow"),
+					tooltip: "Server started, waiting for application...",
+				};
 			case "starting":
 				return {
 					color: new vscode.ThemeColor("charts.yellow"),
@@ -132,6 +137,10 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 				project.description = localize("liberty.view.starting");
 				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://starting/${encoded}`);
 				break;
+			case DevModeState.ServerStarted:
+				project.description = localize("liberty.view.server.started");
+				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://server-started/${encoded}`);
+				break;
 			case DevModeState.Running:
 				project.description = localize("liberty.view.running");
 				project.resourceUri = vscode.Uri.parse(`${LIBERTY_DEV_SCHEME}://running/${encoded}`);
@@ -158,7 +167,7 @@ export class ProjectTreeProvider implements vscode.TreeDataProvider<LibertyProje
 	private _updateAggregatorDescription(aggregator: LibertyProject): void {
 		const descendants = this._registry.findLibertyDescendants(aggregator);
 		const total = descendants.length;
-		const running = descendants.filter(d => d.state === DevModeState.Running).length;
+		const running = descendants.filter(d => d.state === DevModeState.Running || d.state === DevModeState.ServerStarted).length;
 		aggregator.description = running > 0 ? `${running}/${total} Running...` : undefined;
 		this._onDidChangeTreeData.fire(aggregator);
 		if (aggregator.parent) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
     "jakarta.ls.started": "Language Server for Jakarta EE started.",
     "liberty.view.running": "Running...",
     "liberty.view.starting": "Starting...",
+    "liberty.view.server.started": "Server started, waiting for application...",
     "liberty.view.stopping": "Stopping...",
     "no.liberty.projects.found": "No Liberty projects found.",
     "starting.liberty.dev.on": "Starting Liberty dev mode on {0}.",

--- a/src/test/resources/gradle/liberty-gradle-9-test-wrapper-app/build.gradle
+++ b/src/test/resources/gradle/liberty-gradle-9-test-wrapper-app/build.gradle
@@ -33,8 +33,14 @@ dependencies {
      providedCompile 'org.eclipse.microprofile:microprofile:5.0'
      
      // test dependencies
-     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1' 
+     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.1'
      testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
+}
+
+test {
+    useJUnitPlatform()
+    exclude '**/it/**'
 }
 
 liberty {

--- a/src/test/unit/commandUtils.test.ts
+++ b/src/test/unit/commandUtils.test.ts
@@ -1,10 +1,15 @@
 /*
- * Unit tests for Maven command generation — -pl / -am module selector behavior.
+ * Unit tests for Maven and Gradle command generation.
  *
- * Covers:
+ * Maven covers:
  *   1. Child under aggregator: artifactId passed → -pl :<artifactId> -am present
  *   2. Standalone project: no artifactId → -pl absent
  *   3. -pl :<artifactId> -am appears before -f "<pomPath>" (Maven requires this order)
+ *
+ * Gradle covers:
+ *   4. Child under aggregator: projectName passed → task prefixed as :<projectName>:<task>
+ *   5. Standalone project: no projectName → task used as-is
+ *   6. Child command runs from parent directory, not child directory
  */
 
 // This test runs in plain Node — install the vscode fake before any extension imports.
@@ -12,7 +17,7 @@ import { installFakeVscode } from "./fakeVscode";
 installFakeVscode();
 
 import { strict as assert } from "assert";
-import { getCommandForMaven } from "../../util/commandUtils";
+import { getCommandForMaven, getCommandForGradle } from "../../util/commandUtils";
 
 const POM_PATH = "/workspace/my-parent/pom.xml";
 const CHILD_ARTIFACT_ID = "child-module";
@@ -36,5 +41,29 @@ describe("getCommandForMaven — module selector (-pl / -am)", () => {
         assert.ok(plIndex !== -1, `-pl not found in: ${cmd}`);
         assert.ok(fIndex !== -1, `-f not found in: ${cmd}`);
         assert.ok(plIndex < fIndex, `-pl must appear before -f in: ${cmd}`);
+    });
+});
+
+const PARENT_GRADLE_PATH = "/workspace/my-parent/build.gradle";
+const CHILD_GRADLE_PATH = "/workspace/my-parent/sample-ear/build.gradle";
+const GRADLE_PROJECT_NAME = "sample-ear";
+const GRADLE_TASK = "libertyDev";
+
+describe("getCommandForGradle — sub-project task selector (:<projectName>:<task>)", () => {
+    it("prefixes task with :<projectName>: when projectName is provided", async () => {
+        const cmd = await getCommandForGradle(PARENT_GRADLE_PATH, GRADLE_TASK, undefined, undefined, GRADLE_PROJECT_NAME);
+        assert.ok(cmd.includes(`:${GRADLE_PROJECT_NAME}:${GRADLE_TASK}`), `Expected :${GRADLE_PROJECT_NAME}:${GRADLE_TASK} in: ${cmd}`);
+    });
+
+    it("uses task as-is when no projectName is provided", async () => {
+        const cmd = await getCommandForGradle(CHILD_GRADLE_PATH, GRADLE_TASK);
+        assert.ok(cmd.includes(GRADLE_TASK), `Expected ${GRADLE_TASK} in: ${cmd}`);
+        assert.ok(!cmd.includes(`:${GRADLE_TASK}`), `Expected no colon-prefixed task in: ${cmd}`);
+    });
+
+    it("runs from parent directory when projectName is provided", async () => {
+        const cmd = await getCommandForGradle(PARENT_GRADLE_PATH, GRADLE_TASK, undefined, undefined, GRADLE_PROJECT_NAME);
+        assert.ok(cmd.includes("/workspace/my-parent"), `Expected parent dir in: ${cmd}`);
+        assert.ok(!cmd.includes("/workspace/my-parent/sample-ear"), `Expected no child dir in: ${cmd}`);
     });
 });

--- a/src/test/unit/contextValue.test.ts
+++ b/src/test/unit/contextValue.test.ts
@@ -22,6 +22,15 @@ describe("computeContextValue — state 'started'", () => {
     });
 });
 
+describe("computeContextValue — state 'server-started'", () => {
+    it("appends :server-started when server is up but app not yet deployed", () => {
+        assert.equal(computeContextValue("libertyProject:maven", DevModeState.ServerStarted), "libertyProject:maven:server-started");
+    });
+    it("does not append :server-started to an aggregator", () => {
+        assert.equal(computeContextValue("libertyProject:maven:aggregator", DevModeState.ServerStarted), "libertyProject:maven:aggregator");
+    });
+});
+
 describe("computeContextValue — state 'starting' or 'stopping'", () => {
     it("does not append :running when starting", () => {
         assert.equal(computeContextValue("libertyProject:maven", DevModeState.Starting), "libertyProject:maven");
@@ -41,8 +50,10 @@ describe("computeContextValue — aggregator", () => {
 // when-clause regexes (mirror of package.json patterns)
 // ---------------------------------------------------------------------------
 
-const LEAF_NOT_RUNNING = /^libertyProject(?!.*:running)(?!.*:aggregator)/;
+// Start / Custom: excluded when :running, :server-started, or :aggregator
+const LEAF_NOT_RUNNING = /^libertyProject(?!.*:running)(?!.*:server-started)(?!.*:aggregator)/;
 const LEAF_RUNNING     = /^libertyProject.*:running/;
+const LEAF_SERVER_STARTED = /^libertyProject.*:server-started/;
 const AGGREGATOR       = /^libertyProject.*:aggregator/;
 
 describe("when-clause regex — leaf not running (start/custom/start.container)", () => {
@@ -58,23 +69,44 @@ describe("when-clause regex — leaf not running (start/custom/start.container)"
     it("does not match a running leaf", () => {
         assert.ok(!LEAF_NOT_RUNNING.test("libertyProject:maven:running"));
     });
+    it("does not match a server-started leaf", () => {
+        assert.ok(!LEAF_NOT_RUNNING.test("libertyProject:maven:server-started"));
+    });
     it("does not match an aggregator", () => {
         assert.ok(!LEAF_NOT_RUNNING.test("libertyProject:maven:aggregator"));
     });
 });
 
-describe("when-clause regex — leaf running (stop/run.tests/debug)", () => {
+describe("when-clause regex — leaf running (run.tests/debug)", () => {
     it("matches a running maven leaf", () => {
         assert.ok(LEAF_RUNNING.test("libertyProject:maven:running"));
     });
     it("matches a running gradle leaf", () => {
         assert.ok(LEAF_RUNNING.test("libertyProject:gradle:running"));
     });
+    it("does not match a server-started leaf", () => {
+        assert.ok(!LEAF_RUNNING.test("libertyProject:maven:server-started"));
+    });
     it("does not match a stopped leaf", () => {
         assert.ok(!LEAF_RUNNING.test("libertyProject:maven"));
     });
     it("does not match an aggregator", () => {
         assert.ok(!LEAF_RUNNING.test("libertyProject:maven:aggregator"));
+    });
+});
+
+describe("when-clause regex — leaf server-started (stop only)", () => {
+    it("matches a server-started maven leaf", () => {
+        assert.ok(LEAF_SERVER_STARTED.test("libertyProject:maven:server-started"));
+    });
+    it("matches a server-started gradle leaf", () => {
+        assert.ok(LEAF_SERVER_STARTED.test("libertyProject:gradle:server-started"));
+    });
+    it("does not match a fully running leaf", () => {
+        assert.ok(!LEAF_SERVER_STARTED.test("libertyProject:maven:running"));
+    });
+    it("does not match a stopped leaf", () => {
+        assert.ok(!LEAF_SERVER_STARTED.test("libertyProject:maven"));
     });
 });
 

--- a/src/test/unit/devModeState.test.ts
+++ b/src/test/unit/devModeState.test.ts
@@ -38,6 +38,12 @@ describe("LibertyProject.state", () => {
         assert.equal(project.state, DevModeState.Starting);
     });
 
+    it("setState('server-started') sets state to server-started", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState(DevModeState.ServerStarted);
+        assert.equal(project.state, DevModeState.ServerStarted);
+    });
+
     it("setState('started') sets state to started", () => {
         const project = makeProject("libertyProject:maven");
         project.setState(DevModeState.Running);
@@ -69,6 +75,12 @@ describe("filterProjects - liberty.dev.stop", () => {
         assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
     });
 
+    it("includes projects where state is 'server-started'", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState(DevModeState.ServerStarted);
+        assert.equal(filterProjects([project], "liberty.dev.stop").length, 1);
+    });
+
     it("includes projects where state is 'starting'", () => {
         const project = makeProject("libertyProject:maven");
         project.setState(DevModeState.Starting);
@@ -92,6 +104,12 @@ describe("filterProjects - liberty.dev.run.tests", () => {
         assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 1);
     });
 
+    it("excludes projects where state is 'server-started' (app not yet deployed)", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState(DevModeState.ServerStarted);
+        assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 0);
+    });
+
     it("excludes projects where state is undefined", () => {
         const project = makeProject("libertyProject:maven");
         assert.equal(filterProjects([project], "liberty.dev.run.tests").length, 0);
@@ -107,6 +125,12 @@ describe("filterProjects - liberty.dev.debug", () => {
         const project = makeProject("libertyProject:maven");
         project.setState(DevModeState.Running);
         assert.equal(filterProjects([project], "liberty.dev.debug").length, 1);
+    });
+
+    it("excludes projects where state is 'server-started' (app not yet deployed)", () => {
+        const project = makeProject("libertyProject:maven");
+        project.setState(DevModeState.ServerStarted);
+        assert.equal(filterProjects([project], "liberty.dev.debug").length, 0);
     });
 
     it("excludes projects where state is undefined", () => {

--- a/src/util/commandUtils.ts
+++ b/src/util/commandUtils.ts
@@ -57,19 +57,26 @@ export async function getCommandForMaven(pomPath: string, command: string, termi
 
 /**
  * Return the gradle command based on the OS and Terminal for start, start in container, start..
+ * @param buildGradlePath Path to the build.gradle file. For child modules pass the parent's build.gradle.
+ * @param command         Gradle task name (e.g. "libertyDev")
+ * @param terminalType    Type of terminal
+ * @param customCommand   Custom parameters
+ * @param projectName     Optional Gradle sub-project name. When provided the task is prefixed as
+ *                        :<projectName>:<command> so the build runs from the root project directory.
  */
-export async function getCommandForGradle(buildGradlePath: string, command: string, terminalType?: String, customCommand?: string): Promise<string> {
+export async function getCommandForGradle(buildGradlePath: string, command: string, terminalType?: String, customCommand?: string, projectName?: string): Promise<string> {
     let gradleCmdStart = await gradleCmd(buildGradlePath);
     const projectDir = Path.dirname(buildGradlePath);
+    const task = projectName ? `:${projectName}:${command}` : command;
 
     if (gradleCmdStart === "gradle") {
-        return formGradleCommand(projectDir, "gradle", command, customCommand);
+        return formGradleCommand(projectDir, "gradle", task, customCommand);
     }
     //checking the OS type for command customization
     if (isWin()) {
-        return getGradleCommandForWin(gradleCmdStart, projectDir, command, terminalType, customCommand);
+        return getGradleCommandForWin(gradleCmdStart, projectDir, task, terminalType, customCommand);
     } else {
-        return formGradleCommand(projectDir, gradleCmdStart, command, customCommand);
+        return formGradleCommand(projectDir, gradleCmdStart, task, customCommand);
     }
 }
 

--- a/src/util/helperUtil.ts
+++ b/src/util/helperUtil.ts
@@ -53,8 +53,12 @@ export function devModeRequirement(command: string): boolean | undefined {
 }
 
 export function computeContextValue(base: string, state: DevModeState | undefined): string {
-	if (state === DevModeState.Running && !base.includes(":aggregator")) {
+	if (base.includes(":aggregator")) { return base; }
+	if (state === DevModeState.Running) {
 		return `${base}:running`;
+	}
+	if (state === DevModeState.ServerStarted) {
+		return `${base}:server-started`;
 	}
 	return base;
 }
@@ -80,9 +84,10 @@ export function filterProjects(projects: LibertyProject[], command: string): Lib
 			case CMD_START_CONTAINER:
 				return isContainer(cv) && project.state === undefined;
 			case CMD_STOP:
+				return !isAggregator(cv) && project.state !== undefined;
 			case CMD_RUN_TESTS:
 			case CMD_DEBUG:
-				return !isAggregator(cv) && project.state !== undefined;
+				return !isAggregator(cv) && project.state === DevModeState.Running;
 			case "failsafe":
 			case "surefire":
 				return isMaven(cv) && !isAggregator(cv);


### PR DESCRIPTION
- Update Gradle commands to use `:project:task` notations
- Check for server and app started codes in terminal
- Terminal command delay is fixed, command text sent to terminal while monitor is started instead of waiting
- Fix issues with Gradle 9 test project